### PR TITLE
Simplify profiles endpoint

### DIFF
--- a/lib/routers/profile.js
+++ b/lib/routers/profile.js
@@ -11,10 +11,7 @@ router.get('/', (req, res, next) => {
       });
     })
     .then(profiles => {
-      res.response = profiles.map(profile => ({
-        ...profile.dataValues,
-        roles: profile.roles.map(r => r.type)
-      }));
+      res.response = profiles;
       next();
     })
     .catch(next);

--- a/test/index.js
+++ b/test/index.js
@@ -74,6 +74,16 @@ describe('API', () => {
           });
       });
 
+      it('returns a list that includes the `name` virtual property', () => {
+        return request(this.api)
+          .get('/establishment/100/profiles')
+          .expect(200)
+          .expect(response => {
+            assert.equal(response.body.data.length, 1);
+            assert.equal(response.body.data[0].name, 'Linford Christie');
+          });
+      });
+
     });
 
   });


### PR DESCRIPTION
Using the direct result of the sequelize query without mapping preserves virtual properties from the profile model - in particular `name`