### PR TITLE
Include PIL data in profile endpoint response

### DIFF
--- a/lib/routers/profile.js
+++ b/lib/routers/profile.js
@@ -18,7 +18,7 @@ router.get('/', (req, res, next) => {
 });
 
 router.get('/:id', (req, res, next) => {
-  const { Role, Place, Profile } = req.models;
+  const { Role, Place, Profile, PIL } = req.models;
   Promise.resolve()
     .then(() => {
       return Profile.findOne({
@@ -26,12 +26,15 @@ router.get('/:id', (req, res, next) => {
           id: req.params.id,
           establishmentId: req.establishment.id
         },
-        include: {
-          model: Role,
-          include: {
-            model: Place
-          }
-        }
+        include: [
+          {
+            model: Role,
+            include: {
+              model: Place
+            }
+          },
+          { model: PIL }
+        ]
       });
     })
     .then(profile => {

--- a/test/data/default.js
+++ b/test/data/default.js
@@ -1,6 +1,6 @@
 module.exports = models => {
 
-  const { Establishment, Place, Profile } = models;
+  const { Establishment, Place, Profile, PIL } = models;
 
   return Promise.resolve()
     .then(() => {
@@ -32,13 +32,27 @@ module.exports = models => {
             address: '1 Some Road',
             postcode: 'A1 1AA',
             email: 'test@example.com',
-            telephone: '01234567890'
+            telephone: '01234567890',
+            pil: {
+              status: 'active',
+              issueDate: '2017-01-01',
+              revocationDate: null,
+              licenceNumber: 'ABC123',
+              conditions: 'Conditions'
+            }
           }
         ]
       }, {
         include: [
           Place,
-          { model: Profile, as: 'profiles' }
+          {
+            model: Profile,
+            as: 'profiles',
+            include: {
+              model: PIL,
+              as: 'pil'
+            }
+          }
         ]
       });
     })

--- a/test/index.js
+++ b/test/index.js
@@ -97,6 +97,39 @@ describe('API', () => {
           });
       });
 
+      describe('/profile/:id', () => {
+
+        let id;
+
+        beforeEach(() => {
+          return request(this.api)
+            .get('/establishment/100/profiles')
+            .expect(200)
+            .expect(response => {
+              id = response.body.data[0].id;
+            });
+        });
+
+        it('returns the profile data for an individual profile', () => {
+          return request(this.api)
+            .get(`/establishment/100/profile/${id}`)
+            .expect(200)
+            .expect(profile => {
+              assert.equal(profile.body.data.name, 'Linford Christie');
+            });
+        });
+
+        it('includes the PIL data if it exists', () => {
+          return request(this.api)
+            .get(`/establishment/100/profile/${id}`)
+            .expect(200)
+            .expect(profile => {
+              assert.equal(profile.body.data.pil.licenceNumber, 'ABC123');
+            });
+        });
+
+      });
+
     });
 
   });


### PR DESCRIPTION
Adds `pil` property to the response for `/establishment/:id/profile/:id`