### PR TITLE
Include PEL holder in establishment API response

### DIFF
--- a/lib/routers/establishment.js
+++ b/lib/routers/establishment.js
@@ -41,8 +41,15 @@ router.use('/:id', (req, res, next) => {
 });
 
 router.get('/:id', (req, res, next) => {
-  res.response = req.establishment;
-  next();
+  if (!req.establishment) {
+    return next();
+  }
+
+  req.establishment.getPELH()
+    .then(pelh => {
+      res.response = Object.assign(req.establishment.toJSON(), { pelh });
+      next();
+    });
 });
 
 router.use('/:id', (req, res, next) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,11 +5,11 @@
   "requires": true,
   "dependencies": {
     "@asl/migrator": {
-      "version": "1.5.0",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/migrator/-/@asl/migrator-1.5.0.tgz",
-      "integrity": "sha1-4OvHC0Kpy1Cyn3kPsOAxHmxV0yc=",
+      "version": "1.6.0",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/migrator/-/@asl/migrator-1.6.0.tgz",
+      "integrity": "sha1-9hvf0/u2mBTlbaJLlvaElgO6Mrg=",
       "requires": {
-        "@asl/schema": "^1.10.0",
+        "@asl/schema": "^1.11.0",
         "bluebird": "^3.5.1",
         "cli-progress": "^1.7.0",
         "csv-parse": "^2.0.4",
@@ -33,9 +33,9 @@
       "integrity": "sha1-Ye4cKBbGIQOleinlJ/qZE53qz+8="
     },
     "@asl/schema": {
-      "version": "1.10.0",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-1.10.0.tgz",
-      "integrity": "sha1-CpzurwimAmtkNfLOZ7lLxRbGk4k=",
+      "version": "1.12.0",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-1.12.0.tgz",
+      "integrity": "sha1-2ny+5MYAfkRRexiSm+jNgPy7Aw0=",
       "requires": {
         "pg": "^7.4.1",
         "sequelize": "^4.33.1"
@@ -82,9 +82,9 @@
       "integrity": "sha512-Xqg/lIZMrUd0VRmSRbCAewtwGZiAk3mEUDvV4op1tGl+LvyPcb/MIOSxTl9z+9+J+R4/vpjiCAT4xeKzH9ji1w=="
     },
     "@types/node": {
-      "version": "9.4.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.6.tgz",
-      "integrity": "sha512-CTUtLb6WqCCgp6P59QintjHWqzf4VL1uPA27bipLAPxFqrtK1gEYllePzTICGqQ8rYsCbpnsNypXjjDzGAAjEQ=="
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.1.2.tgz",
+      "integrity": "sha512-bjk1RIeZBCe/WukrFToIVegOf91Pebr8cXYBwLBIsfiGWVQ+ifwWsT59H3RxrWzWrzd1l/Amk1/ioY5Fq3/bpA=="
     },
     "abbrev": {
       "version": "1.1.1",
@@ -1345,9 +1345,9 @@
       },
       "dependencies": {
         "colors": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz",
-          "integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg=="
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.0.tgz",
+          "integrity": "sha512-EDpX3a7wHMWFA7PUHWPHNWqOxIIRSJetuwl0AS5Oi/5FMV8kWm69RTlgm00GKjBO1xFHMtBbL49yRtMMdticBw=="
         }
       }
     },
@@ -3212,9 +3212,9 @@
       "dev": true
     },
     "generic-pool": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.4.1.tgz",
-      "integrity": "sha512-xlWAyJMFhjrHYYxoQqT8YQprhSJgMb1AwZjvSzAH8xJEeXpPOWl1zj03heMdJVfa/34BZSclzvGUOaA9qcyIKw=="
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.4.2.tgz",
+      "integrity": "sha512-H7cUpwCQSiJmAHM4c/aFu6fUfrhWXW1ncyh8ftxEPMu6AiYkHw9K8br720TGPZJbk5eOH2bynjZD1yPvdDAmag=="
     },
     "get-stream": {
       "version": "3.0.0",
@@ -3944,11 +3944,6 @@
         "nopt": "~3.0.1"
       }
     },
-    "js-string-escape": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
-      "integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8="
-    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -4330,9 +4325,9 @@
       "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
     },
     "moment-timezone": {
-      "version": "0.5.14",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.14.tgz",
-      "integrity": "sha1-TrOP+VOLgBCLpGekWPPtQmjM/LE=",
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.17.tgz",
+      "integrity": "sha512-Y/JpVEWIOA9Gho4vO15MTnW1FCmHi3ypprrkUaxsZ1TKg3uqC8q/qMBjTddkHoiwwZN3qvZSr4zJP7x9V3LpXA==",
       "requires": {
         "moment": ">= 2.9.0"
       }
@@ -4754,12 +4749,11 @@
       }
     },
     "pg": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-7.4.1.tgz",
-      "integrity": "sha512-Pi5qYuXro5PAD9xXx8h7bFtmHgAQEG6/SCNyi7gS3rvb/ZQYDmxKchfB0zYtiSJNWq9iXTsYsHjrM+21eBcN1A==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-7.4.3.tgz",
+      "integrity": "sha1-97b5P1NA7MJZavu5ShPj1rYJg0s=",
       "requires": {
         "buffer-writer": "1.0.1",
-        "js-string-escape": "1.0.1",
         "packet-reader": "0.3.1",
         "pg-connection-string": "0.1.3",
         "pg-pool": "~2.0.3",
@@ -5373,9 +5367,9 @@
       }
     },
     "sequelize": {
-      "version": "4.33.4",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-4.33.4.tgz",
-      "integrity": "sha512-PoKGxgHkc701Nfm0GO1/Sl3VJUALVHdI1k4TViDIDpUwYu98/qxkDSsZeT0geq1xKVNwRzYjhO5zSH+y1C3xQw==",
+      "version": "4.37.8",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-4.37.8.tgz",
+      "integrity": "sha512-I1w/LROq1Ro1i05jIY3bTqcbFxx2kwrRw0XGYYz0uvv3kHurxJZMnxfJrn95vc5Dk0fG3A2EvlAVxUfnSAiNRQ==",
       "requires": {
         "bluebird": "^3.5.0",
         "cls-bluebird": "^2.1.0",
@@ -5392,7 +5386,7 @@
         "terraformer-wkt-parser": "^1.1.2",
         "toposort-class": "^1.0.1",
         "uuid": "^3.2.1",
-        "validator": "^9.4.0",
+        "validator": "^9.4.1",
         "wkx": "^0.4.1"
       }
     },
@@ -5881,10 +5875,11 @@
       }
     },
     "terraformer-wkt-parser": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/terraformer-wkt-parser/-/terraformer-wkt-parser-1.1.2.tgz",
-      "integrity": "sha1-M2oMj8gglKWv+DKI9prt7NNpvww=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/terraformer-wkt-parser/-/terraformer-wkt-parser-1.2.0.tgz",
+      "integrity": "sha512-QU3iA54St5lF8Za1jg1oj4NYc8sn5tCZ08aNSWDeGzrsaV48eZk1iAVWasxhNspYBoCqdHuoot1pUTUrE1AJ4w==",
       "requires": {
+        "@types/geojson": "^1.0.0",
         "terraformer": "~1.0.5"
       }
     },
@@ -6263,9 +6258,9 @@
       }
     },
     "validator": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-9.4.0.tgz",
-      "integrity": "sha512-ftkCYp/7HrGdybVCuwSje07POAd93ksZJpb5GVDBzm8SLKIm3QMJcZugb5dOJsONBoWhIXl0jtoGHTyou3DAgA=="
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-9.4.1.tgz",
+      "integrity": "sha512-YV5KjzvRmSyJ1ee/Dm5UED0G+1L4GZnLN3w6/T+zZm8scVua4sOhYKWTUrKa0H/tMiJyO9QLHMPN+9mB/aMunA=="
     },
     "vary": {
       "version": "1.1.2",
@@ -6321,9 +6316,9 @@
       }
     },
     "wkx": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.4.2.tgz",
-      "integrity": "sha1-d201pjSlwi5lbkdEvetU+D/Szo0=",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.4.5.tgz",
+      "integrity": "sha512-01dloEcJZAJabLO5XdcRgqdKpmnxS0zIT02LhkdWOZX2Zs2tPM6hlZ4XG9tWaWur1Qd1OO4kJxUbe2+5BofvnA==",
       "requires": {
         "@types/node": "*"
       }

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   },
   "homepage": "https://github.com/UKHomeOffice/asl-public-api#readme",
   "dependencies": {
-    "@asl/migrator": "^1.5.0",
+    "@asl/migrator": "^1.6.0",
     "@asl/mocks": "^2.2.0",
-    "@asl/schema": "^1.10.0",
+    "@asl/schema": "^1.12.0",
     "@asl/service": "^1.4.0",
     "express": "^4.16.2",
     "lodash": "^4.17.5"

--- a/test/data/default.js
+++ b/test/data/default.js
@@ -54,7 +54,21 @@ module.exports = models => {
             }
           }
         ]
-      });
+      })
+        .then(establishment => {
+          return establishment.createRole({
+            type: 'pelh',
+            profile: {
+              title: 'Dr',
+              firstName: 'Noddy',
+              lastName: 'Holder',
+              address: '1 Some Road',
+              postcode: 'A1 1AA',
+              email: 'test@example.com',
+              telephone: '01234567890'
+            }
+          }, { include: Profile });
+        });
     })
     .then(() => {
       return Establishment.create({

--- a/test/index.js
+++ b/test/index.js
@@ -58,6 +58,15 @@ describe('API', () => {
         });
     });
 
+    it('includes the details fo the licence holder as `pelh`', () => {
+      return request(this.api)
+        .get('/establishment/100')
+        .expect(200)
+        .expect(response => {
+          assert.equal(response.body.data.pelh.name, 'Noddy Holder');
+        });
+    });
+
     describe('/places', () => {
 
       it('returns only the places related to the current establishment', () => {


### PR DESCRIPTION
Adds a `pelh` property to the establishment API which includes the profile information of the licence holder.

Also fixes an issue with the data seeding that doesn't add an establishment ID to the PEL holder profile, which causes the bug described in AS-349.