### PR TITLE
Remove .npmrc from docker once install is complete

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ COPY package-lock.json /app/package-lock.json
 RUN npm install --production --no-optional
 COPY . /app
 
+RUN rm /app/.npmrc
+
 USER nodejs
 
 CMD node index.js


### PR DESCRIPTION
This means that npm commands can be run on the container without needing to have the env vars specified to access artifactory. In particular - `npm run migrate` on deployed servers.