### PR TITLE
Remove roles and places from top-level establishment response

### DIFF
--- a/lib/routers/establishment.js
+++ b/lib/routers/establishment.js
@@ -18,7 +18,7 @@ router.get('/', (req, res, next) => {
 
 router.use('/:id', (req, res, next) => {
 
-  const { Establishment, Role, Place, Profile, Authorisation } = req.models;
+  const { Establishment, Authorisation } = req.models;
 
   Promise.resolve()
     .then(() => {
@@ -26,8 +26,6 @@ router.use('/:id', (req, res, next) => {
         .findOne({
           where: { id: req.params.id },
           include: [
-            { model: Role, include: { model: Profile } },
-            { model: Place },
             { model: Authorisation }
           ]
         });


### PR DESCRIPTION
These are no longer needed, so removing them will improve performance