### PR TITLE
Use uid to run as user in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,6 @@ COPY . /app
 
 RUN rm /app/.npmrc
 
-USER nodejs
+USER 999
 
 CMD node index.js


### PR DESCRIPTION
Images need to run with a numeric uid, and not a username.

As per https://github.com/UKHomeOffice/application-container-platform/blob/master/how-to-docs/pod-security-policies.md#runasuser