### PR TITLE
Only send establishment name and id in meta payload

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -3,8 +3,6 @@ const db = require('@asl/schema');
 
 const errorHandler = require('./error-handler');
 
-const {omit} = require('lodash');
-
 module.exports = settings => {
   const app = api(settings);
 
@@ -26,7 +24,10 @@ module.exports = settings => {
       };
       if (req.establishment) {
         response.meta = {
-          establishment: omit(req.establishment.toJSON(), 'places', 'roles')
+          establishment: {
+            id: req.establishment.id,
+            name: req.establishment.name
+          }
         };
       }
       return res.json(response);


### PR DESCRIPTION
This will reduce the amount of data over the wire that isn't being used in the client.