### PR TITLE
Use `findAll` on Place model to list places

### DIFF
--- a/lib/routers/places.js
+++ b/lib/routers/places.js
@@ -55,11 +55,11 @@ router.param('id', (req, res, next, id) => {
 });
 
 router.get('/', (req, res, next) => {
-  const { Role, Profile } = req.models;
+  const { Place, Role, Profile } = req.models;
   Promise.resolve()
     .then(() => {
-      return req.establishment.getPlaces({
-        where: req.where,
+      return Place.findAll({
+        where: { ...req.where, establishmentId: req.establishment.id },
         include: {
           model: Role,
           as: 'nacwo',

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,9 +33,9 @@
       "integrity": "sha1-R2LRO9P6+BUS2z2Juz60uRuXl4I="
     },
     "@asl/schema": {
-      "version": "1.13.2",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-1.13.2.tgz",
-      "integrity": "sha1-PLhrtPCxbOebkN8g6oRFxMa0xbg=",
+      "version": "1.14.0",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-1.14.0.tgz",
+      "integrity": "sha1-2pqK6LiWuQRw8dYbsQ9naIK15Zw=",
       "requires": {
         "pg": "^7.4.1",
         "sequelize": "^4.33.1"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@asl/migrator": "^1.8.3",
     "@asl/mocks": "^2.3.3",
-    "@asl/schema": "^1.13.2",
+    "@asl/schema": "^1.14.0",
     "@asl/service": "^3.0.0",
     "aws-sdk": "^2.266.1",
     "express": "^4.16.2",


### PR DESCRIPTION
Using `findAll` allows the query to make use of the default query scope on the Place model, which will ignore deleted places by default.