### PR TITLE
Fix bug with roles without places being ignored

### DIFF
--- a/lib/routers/profile.js
+++ b/lib/routers/profile.js
@@ -32,7 +32,8 @@ router.get('/:id', (req, res, next) => {
           {
             model: Role,
             include: {
-              model: Place
+              model: Place,
+              required: false
             }
           },
           PIL,

--- a/lib/routers/roles.js
+++ b/lib/routers/roles.js
@@ -10,7 +10,7 @@ router.get('/', (req, res, next) => {
         where: req.where,
         include: [
           { model: Profile },
-          { model: Place }
+          { model: Place, required: false }
         ]
       });
     })
@@ -32,7 +32,7 @@ router.get('/:id', (req, res, next) => {
         },
         include: [
           { model: Profile },
-          { model: Place }
+          { model: Place, required: false }
         ]
       });
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,15 @@
         "uuid": "^3.2.1"
       },
       "dependencies": {
+        "@asl/schema": {
+          "version": "1.14.0",
+          "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-1.14.0.tgz",
+          "integrity": "sha1-2pqK6LiWuQRw8dYbsQ9naIK15Zw=",
+          "requires": {
+            "pg": "^7.4.1",
+            "sequelize": "^4.33.1"
+          }
+        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",

--- a/test/data/default.js
+++ b/test/data/default.js
@@ -28,6 +28,7 @@ module.exports = models => {
         ],
         profiles: [
           {
+            id: 'f0835b01-00a0-4c7f-954c-13ed2ef7efd9',
             title: 'Dr',
             firstName: 'Linford',
             lastName: 'Christie',
@@ -67,9 +68,28 @@ module.exports = models => {
               address: '1 Some Road',
               postcode: 'A1 1AA',
               email: 'test@example.com',
-              telephone: '01234567890'
+              telephone: '01234567890',
+              establishmentId: 100
             }
-          }, { include: Profile });
+          }, { include: Profile })
+            .then(() => establishment);
+        })
+        .then(establishment => {
+          return establishment.createRole({
+            type: 'nacwo',
+            profile: {
+              id: 'a942ffc7-e7ca-4d76-a001-0b5048a057d9',
+              title: 'Dr',
+              firstName: 'Clive',
+              lastName: 'Nacwo',
+              address: '1 Some Road',
+              postcode: 'A1 1AA',
+              email: 'test@example.com',
+              telephone: '01234567890',
+              establishmentId: 100
+            }
+          }, { include: Profile })
+            .then(() => establishment);
         });
     })
     .then(() => {

--- a/test/specs/index.js
+++ b/test/specs/index.js
@@ -193,9 +193,10 @@ describe('API', () => {
           .get('/establishment/100/profiles')
           .expect(200)
           .expect(response => {
-            assert.equal(response.body.data.length, 1);
-            assert.equal(response.body.data[0].firstName, 'Linford');
-            assert.equal(response.body.data[0].lastName, 'Christie');
+            assert.equal(response.body.data.length, 3);
+            response.body.data.forEach(profile => {
+              assert.equal(profile.establishmentId, 100);
+            });
           });
       });
 
@@ -204,27 +205,18 @@ describe('API', () => {
           .get('/establishment/100/profiles')
           .expect(200)
           .expect(response => {
-            assert.equal(response.body.data.length, 1);
-            assert.equal(response.body.data[0].name, 'Linford Christie');
+            assert.equal(response.body.data.length, 3);
+            response.body.data.forEach(profile => {
+              assert.equal(typeof profile.name, 'string');
+            });
           });
       });
 
       describe('/profile/:id', () => {
 
-        let id;
-
-        beforeEach(() => {
-          return request(this.api)
-            .get('/establishment/100/profiles')
-            .expect(200)
-            .expect(response => {
-              id = response.body.data[0].id;
-            });
-        });
-
         it('returns the profile data for an individual profile', () => {
           return request(this.api)
-            .get(`/establishment/100/profile/${id}`)
+            .get('/establishment/100/profile/f0835b01-00a0-4c7f-954c-13ed2ef7efd9')
             .expect(200)
             .expect(profile => {
               assert.equal(profile.body.data.name, 'Linford Christie');
@@ -233,13 +225,36 @@ describe('API', () => {
 
         it('includes the PIL data if it exists', () => {
           return request(this.api)
-            .get(`/establishment/100/profile/${id}`)
+            .get('/establishment/100/profile/f0835b01-00a0-4c7f-954c-13ed2ef7efd9')
             .expect(200)
             .expect(profile => {
               assert.equal(profile.body.data.pil.licenceNumber, 'ABC123');
             });
         });
 
+        it('returns a NACWO role for NACWOs without places', () => {
+          return request(this.api)
+            .get('/establishment/100/profile/a942ffc7-e7ca-4d76-a001-0b5048a057d9')
+            .expect(200)
+            .expect(profile => {
+              assert.deepEqual(profile.body.data.roles.map(r => r.type), ['nacwo']);
+            });
+        });
+
+      });
+
+    });
+
+    describe('/roles', () => {
+
+      it('returns NACWOs who do not have places assigned', () => {
+        return request(this.api)
+          .get('/establishment/100/roles?type=nacwo')
+          .expect(200)
+          .expect(response => {
+            assert.equal(response.body.data.length, 1);
+            assert.equal(response.body.data[0].type, 'nacwo');
+          });
       });
 
     });


### PR DESCRIPTION
Because adding a default scope to places resulted in a where clause being added to all `Place` queries, this meant that associated models would not return if they had no places that satisfied the `where` clause.

This resulted in NACWO lists being returned empty (or only including NACWOs who had previously had places assigned) and also profiles not recognising that a they had a NACWO role.

The fix was to add a `required` property to the association query.

See http://docs.sequelizejs.com/manual/tutorial/models-usage.html#nested-eager-loading