### PR TITLE
Name docker image tag more specifically

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -34,7 +34,7 @@ pipeline:
     environment:
       - DOCKER_HOST=tcp://172.17.0.1:2375
     commands:
-      - docker build --build-arg NPM_AUTH_USERNAME=$${NPM_AUTH_USERNAME} --build-arg NPM_AUTH_TOKEN=$${NPM_AUTH_TOKEN} -t asl .
+      - docker build --build-arg NPM_AUTH_USERNAME=$${NPM_AUTH_USERNAME} --build-arg NPM_AUTH_TOKEN=$${NPM_AUTH_TOKEN} -t asl-public-api .
     when:
       branch: master
       event: [push, tag]
@@ -47,7 +47,7 @@ pipeline:
       - DOCKER_HOST=tcp://172.17.0.1:2375
     commands:
       - docker login -u="ukhomeofficedigital+asl" -p=$${DOCKER_PASSWORD} quay.io
-      - docker tag asl quay.io/ukhomeofficedigital/asl-public-api:$${DRONE_COMMIT_SHA}
+      - docker tag asl-public-api quay.io/ukhomeofficedigital/asl-public-api:$${DRONE_COMMIT_SHA}
       - docker push quay.io/ukhomeofficedigital/asl-public-api:$${DRONE_COMMIT_SHA}
     when:
       branch: master


### PR DESCRIPTION
I think the issue we've had with deployment are a result of two builds running simultaneously, tagging the images with the same name, on the same DOCKER_HOST. The `asl` project ended up deploying an `asl-public-api` image.

Renaming the tagged image to match the name of the project should mitigate against this.