### PR TITLE
Fix bug with name search removing role filters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@asl/schema": {
-      "version": "3.1.0",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-3.1.0.tgz",
-      "integrity": "sha1-AyqQcCLz4khbKE6AG9LWEs2+4Ak=",
+      "version": "3.1.1",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-3.1.1.tgz",
+      "integrity": "sha1-KSVvZunWrNSHEyrbij9GTeospnw=",
       "requires": {
         "knex": "^0.15.2",
         "lodash": "^4.17.10",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/UKHomeOffice/asl-public-api#readme",
   "dependencies": {
-    "@asl/schema": "^3.1.0",
+    "@asl/schema": "^3.1.1",
     "@asl/service": "^3.0.0",
     "express": "^4.16.3",
     "lodash": "^4.17.5",

--- a/test/data/default.js
+++ b/test/data/default.js
@@ -1,6 +1,6 @@
 module.exports = models => {
 
-  const { Establishment, Place, Profile, PIL, Role } = models;
+  const { Establishment, Role } = models;
 
   return Promise.resolve()
     .then(() => {
@@ -71,18 +71,16 @@ module.exports = models => {
             postcode: 'A1 1AA',
             email: 'test3@example.com',
             telephone: '01234567890'
-          }
-        ]
-      }, {
-        include: [
-          Place,
+          },
           {
-            model: Profile,
-            as: 'profiles',
-            include: {
-              model: PIL,
-              as: 'pil'
-            }
+            id: 'a942ffc7-e7ca-4d76-a001-0b5048a057d0',
+            title: 'Dr',
+            firstName: 'Noddy',
+            lastName: 'Nacwo',
+            address: '1 Some Road',
+            postcode: 'A1 1AA',
+            email: 'test4@example.com',
+            telephone: '01234567890'
           }
         ]
       })
@@ -100,6 +98,13 @@ module.exports = models => {
                 establishmentId: establishment.id,
                 type: 'nacwo',
                 profileId: 'a942ffc7-e7ca-4d76-a001-0b5048a057d9'
+              });
+            })
+            .then(() => {
+              return Role.query().insert({
+                establishmentId: establishment.id,
+                type: 'nacwo',
+                profileId: 'a942ffc7-e7ca-4d76-a001-0b5048a057d0'
               });
             });
         });
@@ -134,14 +139,9 @@ module.exports = models => {
             lastName: 'Jackson',
             address: '1 Some Road',
             postcode: 'A1 1AA',
-            email: 'test4@example.com',
+            email: 'test5@example.com',
             telephone: '01234567890'
           }
-        ]
-      }, {
-        include: [
-          Place,
-          { model: Profile, as: 'profiles' }
         ]
       });
     });

--- a/test/specs/index.js
+++ b/test/specs/index.js
@@ -257,7 +257,7 @@ describe('API', () => {
           .get('/establishment/100/profiles')
           .expect(200)
           .expect(response => {
-            assert.equal(response.body.data.length, 3);
+            assert.equal(response.body.data.length, 4);
             response.body.data.forEach(profile => {
               profile.establishments.forEach(establishment => {
                 assert.equal(establishment.id, 100);
@@ -271,7 +271,7 @@ describe('API', () => {
           .get('/establishment/100/profiles')
           .expect(200)
           .expect(response => {
-            assert.equal(response.body.data.length, 3);
+            assert(response.body.data.length > 0);
             response.body.data.forEach(profile => {
               assert.equal(typeof profile.name, 'string');
             });
@@ -288,7 +288,11 @@ describe('API', () => {
           .get(`/establishment/100/profiles?${query}`)
           .expect(200)
           .expect(response => {
-            assert.equal(response.body.data.length, 1);
+            assert.equal(response.body.data.length, 2);
+            response.body.data.forEach(profile => {
+              assert.equal(profile.roles.length, 1);
+              assert.equal(profile.roles[0].type, 'nacwo');
+            });
           });
       });
 
@@ -364,6 +368,7 @@ describe('API', () => {
           .expect(200)
           .expect(response => {
             assert.equal(response.body.data.length, 1);
+            assert.equal(response.body.data[0].name, 'Noddy Holder');
           });
       });
 
@@ -407,8 +412,9 @@ describe('API', () => {
           .get('/establishment/100/roles?type=nacwo')
           .expect(200)
           .expect(response => {
-            assert.equal(response.body.data.length, 1);
+            assert.equal(response.body.data.length, 2);
             assert.equal(response.body.data[0].type, 'nacwo');
+            assert.equal(response.body.data[1].type, 'nacwo');
           });
       });
 


### PR DESCRIPTION
Fix was in @asl/schema, so update to include new version.

Improve unit tests by adding a new nacwo with the same name as the PEL holder. This ensures that both the name filter and role filter need to have been correctly applied to receive the expected result.

Fix other tests to reflect the addition of a new nacwo, and make some assertions stronger.