### PR TITLE
Add regression tests for schema searching bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@asl/schema": {
-      "version": "3.2.0",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-3.2.0.tgz",
-      "integrity": "sha1-0dfft+PKU6vt0HKOJ/OiBUk9nXE=",
+      "version": "3.2.1",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-3.2.1.tgz",
+      "integrity": "sha1-/6zY0uJVfTRk03wnsAWMxBgZZvQ=",
       "requires": {
         "knex": "^0.15.2",
         "lodash": "^4.17.10",
@@ -4294,9 +4294,9 @@
           }
         },
         "commander": {
-          "version": "2.17.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.0.tgz",
-          "integrity": "sha512-477o1hdVORiFlZxw8wgsXYCef3lh0zl/OV0FTftqiDxJSWw6dPQ2ipS4k20J2qBcsmsmLKSyr2iFrf9e3JGi4w=="
+          "version": "2.17.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
         },
         "has-flag": {
           "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/UKHomeOffice/asl-public-api#readme",
   "dependencies": {
-    "@asl/schema": "^3.2.0",
+    "@asl/schema": "^3.2.1",
     "@asl/service": "^3.0.0",
     "express": "^4.16.3",
     "lodash": "^4.17.5",

--- a/test/data/default.js
+++ b/test/data/default.js
@@ -103,6 +103,20 @@ module.exports = models => {
                 holding: JSON.stringify(['STH']),
                 deleted: '2018-01-01'
               }
+            ],
+            projects: [
+              {
+                title: 'Test project 1',
+                licenceHolderId: 'f0835b01-00a0-4c7f-954c-13ed2ef7efd9',
+                expiryDate: '2040-01-01T12:00:00Z',
+                licenceNumber: 'abc123'
+              },
+              {
+                title: 'Test project 3',
+                licenceHolderId: 'f0835b01-00a0-4c7f-954c-13ed2ef7efd9',
+                expiryDate: '2010-01-01T12:00:00Z',
+                licenceNumber: 'abc456'
+              }
             ]
           },
           {
@@ -125,6 +139,14 @@ module.exports = models => {
                 name: 'Room 102',
                 suitability: JSON.stringify(['SA']),
                 holding: JSON.stringify(['STH'])
+              }
+            ],
+            projects: [
+              {
+                title: 'Test project 2',
+                licenceHolderId: 'ae28fb31-d867-4371-9b4f-79019e71232e',
+                expiryDate: '2040-01-01T12:00:00Z',
+                licenceNumber: 'abc789'
               }
             ]
           }]);

--- a/test/specs/index.js
+++ b/test/specs/index.js
@@ -450,6 +450,20 @@ describe('API', () => {
 
     });
 
+    describe('/projects', () => {
+
+      it('returns only the current establishments projects when searching - bugfix', () => {
+        return request(this.api)
+          .get('/establishment/100/projects?search=abc') // "abc" matches licence number for all projects
+          .expect(200)
+          .expect(response => {
+            assert.equal(response.body.data.length, 1, 'Returns exactly one project');
+            assert.equal(response.body.data[0].title, 'Test project 1');
+          });
+      });
+
+    });
+
   });
 
 });


### PR DESCRIPTION
Fixed in `schema@3.2.1` there was a bug where a match in the licence number or licence holder name would cause previous query clauses to be ignored.