### PR TITLE
AS-600: don't validate against comments prop in places

### DIFF
--- a/lib/routers/places.js
+++ b/lib/routers/places.js
@@ -2,6 +2,7 @@ const { Router } = require('express');
 const isUUID = require('uuid-validate');
 const { NotFoundError } = require('../errors');
 const permissions = require('../middleware/permissions');
+const { omit } = require('lodash');
 
 const submit = (action) => {
   return (req, res, next) => {
@@ -22,11 +23,14 @@ const submit = (action) => {
 
 const validateSchema = () => {
   return (req, res, next) => {
+    const ignoredProps = ['comments'];
     let data = { ...req.body, establishmentId: req.establishment.id };
 
     if (res.place) {
       data = Object.assign({}, res.place, data);
     }
+
+    data = omit(data, ignoredProps);
 
     const { Place } = req.models;
     const error = Place.validate(data);

--- a/test/specs/places.js
+++ b/test/specs/places.js
@@ -104,6 +104,20 @@ describe('/places', () => {
       });
   });
 
+  it('can pass comments property without failing validation', () => {
+    const input = {
+      site: 'Lunar House 3rd floor',
+      name: '83',
+      suitability: ['LA', 'DOG'],
+      holding: ['NOH'],
+      comments: 'this should not fail validation'
+    };
+    return request(this.api)
+      .post('/establishment/100/places')
+      .send(input)
+      .expect(200);
+  });
+
   it('returns 400 for invalid or missing data', () => {
     const input = {
       // requires "name"


### PR DESCRIPTION
We do not save the comments property to the db, so our schema omits it, but we still need to be able to pass the validation.