### PR TITLE
Fix rate limiter config

### DIFF
--- a/.kube.dev.yaml
+++ b/.kube.dev.yaml
@@ -37,7 +37,7 @@
       secret: true
       name: asl-dev-redis
       key: pass
-    RATE_LIMIT_TOTAL: 1000
+    RATE_LIMIT_TOTAL: '"1000"'
   nginx:
     ADD_NGINX_SERVER_CFG: add_header Cache-Control private;
 

--- a/config.js
+++ b/config.js
@@ -21,6 +21,6 @@ module.exports = {
     password: process.env.REDIS_PASSWORD
   },
   limiter: {
-    total: process.env.RATE_LIMIT_TOTAL
+    total: parseInt(process.env.RATE_LIMIT_TOTAL, 10) || 0
   }
 };

--- a/test/helpers/api.js
+++ b/test/helpers/api.js
@@ -8,7 +8,7 @@ require('dotenv').config();
 
 const settings = {
   database: process.env.POSTGRES_DB || 'asl-test',
-  user: process.env.POSTGRES_USER,
+  user: process.env.POSTGRES_USER || 'postgres',
   host: process.env.POSTGRES_HOST || 'localhost'
 };
 

--- a/test/specs/rate-limiting.js
+++ b/test/specs/rate-limiting.js
@@ -7,7 +7,7 @@ require('dotenv').config();
 
 const settings = {
   database: process.env.POSTGRES_DB || 'asl-test',
-  user: process.env.POSTGRES_USER,
+  user: process.env.POSTGRES_USER || 'postgres',
   host: process.env.POSTGRES_HOST || 'localhost'
 };
 


### PR DESCRIPTION
Environment variables always need to be set as strings. 

Wrap the value in enough quotes to keep it as a string when it finally gets parsed into deployment config and then restore it to an integer again in code.