### PR TITLE
Fix non-deterministic rate limiter tests

### DIFF
--- a/lib/middleware/rate-limiter.js
+++ b/lib/middleware/rate-limiter.js
@@ -1,0 +1,18 @@
+const redis = require('redis');
+const limiter = require('express-limiter');
+
+const { RateLimitedError } = require('../errors');
+
+module.exports = settings => {
+  const client = redis.createClient(settings.redis);
+
+  return limiter(null, client)({
+    lookup: ['user.id'],
+    total: settings.limiter.total,
+    expire: 1000 * 60 * 60,
+    whitelist: req => req.path === '/me',
+    onRateLimited: function (req, res, next) {
+      next(new RateLimitedError());
+    }
+  });
+};

--- a/lib/middleware/rate-limiter/express-limiter.js
+++ b/lib/middleware/rate-limiter/express-limiter.js
@@ -1,0 +1,68 @@
+/*****
+This is a port of npmjs.com/express-limiter with some minor functionality changes:
+
+* Limits are global here, where in `express-limiter` they are applied per route/method
+* Unused functionality is removed so `app` no longer needs to be passed as a parameter
+* Updated code to ESmodernish
+*****/
+
+module.exports = db => {
+  return opts => {
+    return (req, res, next) => {
+      if (opts.whitelist && opts.whitelist(req)) {
+        return next();
+      }
+      opts.lookup = Array.isArray(opts.lookup) ? opts.lookup : [opts.lookup];
+      opts.onRateLimited = typeof opts.onRateLimited === 'function' ? opts.onRateLimited : (req, res, next) => {
+        res.status(429).send('Rate limit exceeded');
+      };
+
+      const lookups = opts.lookup.map(item => {
+        return item + ':' + item.split('.').reduce((prev, cur) => {
+          return prev[cur];
+        }, req);
+      }).join(':');
+      const key = 'ratelimit:' + lookups;
+      db.get(key, (err, limit) => {
+        if (err && opts.ignoreErrors) {
+          return next();
+        }
+        const now = Date.now();
+        limit = limit ? JSON.parse(limit) : {
+          total: opts.total,
+          remaining: opts.total,
+          reset: now + opts.expire
+        };
+
+        if (now > limit.reset) {
+          limit.reset = now + opts.expire;
+          limit.remaining = opts.total;
+        }
+
+        // do not allow negative remaining
+        limit.remaining = Math.max(Number(limit.remaining) - 1, -1);
+
+        db.set(key, JSON.stringify(limit), 'PX', opts.expire, function (e) {
+          if (!opts.skipHeaders) {
+            res.set('X-RateLimit-Limit', limit.total);
+            res.set('X-RateLimit-Reset', Math.ceil(limit.reset / 1000));
+            res.set('X-RateLimit-Remaining', Math.max(limit.remaining, 0));
+          }
+
+          if (limit.remaining >= 0) {
+            return next();
+          }
+
+          const after = (limit.reset - Date.now()) / 1000;
+
+          if (!opts.skipHeaders) {
+            res.set('Retry-After', after);
+          }
+
+          opts.onRateLimited(req, res, next);
+        });
+
+      });
+    };
+  };
+};

--- a/lib/middleware/rate-limiter/index.js
+++ b/lib/middleware/rate-limiter/index.js
@@ -1,16 +1,17 @@
 const redis = require('redis');
-const limiter = require('express-limiter');
+const { RateLimitedError } = require('../../errors');
 
-const { RateLimitedError } = require('../errors');
+const limiter = require('./express-limiter');
 
 module.exports = settings => {
   const client = redis.createClient(settings.redis);
 
-  return limiter(null, client)({
+  return limiter(client)({
     lookup: ['user.id'],
     total: settings.limiter.total,
     expire: 1000 * 60 * 60,
     whitelist: req => req.path === '/me',
+    ignoreErrors: false,
     onRateLimited: function (req, res, next) {
       next(new RateLimitedError());
     }

--- a/test/helpers/api.js
+++ b/test/helpers/api.js
@@ -11,16 +11,16 @@ const settings = {
 };
 
 module.exports = {
-  create: () => {
+  create: (options = {}) => {
     return Database(settings).init(data.default)
       .then(() => Workflow())
       .then(workflow => {
-        const api = Api({
+        const api = Api(Object.assign({
           auth: false,
           log: { level: 'error' },
           db: settings,
           workflow: workflow.url
-        });
+        }, options));
         this.workflow = workflow;
         this.api = WithUser(api, {});
         return {


### PR DESCRIPTION
Also fixes the rate limiter along the way as it wasn't behaving exactly how we want.

The `express-limiter` module was only applying limits per route/method, so if a user hit a limit requesting one route, then they would still be able to make requests to any other route (or the same route with a different method). We want the limit to be shared across all routes/methods, so need to change the `express-limiter` code. This has been done by pulling the module code into our build and modifying there.

Additionally:

* resolve race condition where redis deletion in the test runner `beforeEach` was not handled asyncly. Now waits for callback before running tests. I _think_ this was the cause of the original bug/flaky test.
* include database setup in rate-limiter tests so that profile endpoint test is not dependent on other tests that do perform database setup, and can be run in isolation.