### PR TITLE
Process one module at a time

### DIFF
--- a/lib/routers/training-modules.js
+++ b/lib/routers/training-modules.js
@@ -1,19 +1,13 @@
 const { Router } = require('express');
-const { omit } = require('lodash');
 
 const submit = (action) => {
   return (req, res, next) => {
-    const certificate = omit(req.body, 'modules');
-    const requests = req.body.modules.map(module => {
-      const params = {
-        action,
-        model: 'trainingModule',
-        data: { ...certificate, module }
-      };
-      return req.workflow(params);
-    });
-
-    return Promise.all(requests)
+    const params = {
+      action,
+      model: 'trainingModule',
+      data: { ...req.body }
+    };
+    req.workflow(params)
       .then(response => {
         res.response = response;
         next();

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha1-bC0NbCnxc4g4h5/WXEAwcH/I/ds="
     },
     "@asl/schema": {
-      "version": "5.0.0",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-5.0.0.tgz",
-      "integrity": "sha1-LLLYi3oOLbYxPRJEdK/mSJ6iFLk=",
+      "version": "5.0.1",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-5.0.1.tgz",
+      "integrity": "sha1-2xdvqgzfNr4O2xhGwjGvhFQcFg0=",
       "requires": {
         "@asl/constants": "^0.0.1",
         "knex": "^0.15.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/UKHomeOffice/asl-public-api#readme",
   "dependencies": {
-    "@asl/schema": "^5.0.0",
+    "@asl/schema": "^5.0.1",
     "@asl/service": "^5.3.0",
     "express": "^4.16.3",
     "lodash": "^4.17.5",


### PR DESCRIPTION
Previously we were sending the modules combined into one api request, but this is causing problems with the schema validation.

As a stopgap until we refactor the schema, this just processes a single module per request.