### PR TITLE
Support pagination on establishment list endpoint

### DIFF
--- a/lib/routers/establishment.js
+++ b/lib/routers/establishment.js
@@ -27,12 +27,21 @@ router.param('establishment', (req, res, next, id) => {
 });
 
 router.get('/', permissions('establishment.list'), (req, res, next) => {
+  let { limit, offset } = req.query;
   const { Establishment } = req.models;
-  Promise.resolve()
-    .then(() => Establishment.query())
-    .then(result => {
-      res.response = result;
-      next();
+  Promise.all([
+    Establishment.count(),
+    Establishment.paginate({
+      query: Establishment.query(),
+      limit,
+      offset
+    })
+  ])
+    .then(([total, establishments]) => {
+      res.meta.total = total;
+      res.meta.count = establishments.total;
+      res.response = establishments.results;
+      return next();
     })
     .catch(next);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha1-bC0NbCnxc4g4h5/WXEAwcH/I/ds="
     },
     "@asl/schema": {
-      "version": "5.0.2",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-5.0.2.tgz",
-      "integrity": "sha1-58zOucXstZtQTGDtuMRTc/aUkXE=",
+      "version": "5.2.0",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-5.2.0.tgz",
+      "integrity": "sha1-u49R/SVQy6PxUGNJP8aIRelpa58=",
       "requires": {
         "@asl/constants": "^0.0.1",
         "knex": "^0.15.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/UKHomeOffice/asl-public-api#readme",
   "dependencies": {
-    "@asl/schema": "^5.0.2",
+    "@asl/schema": "^5.2.0",
     "@asl/service": "^5.3.0",
     "express": "^4.16.3",
     "lodash": "^4.17.5",


### PR DESCRIPTION
The data table component that makes requests to this endpoint expects pagination metadata to exist on the response.

Port the pagination behaviour from other list endpoints to here in order to support pagination of the establishment list.

Dependent on https://github.com/UKHomeOffice/asl-schema/pull/75