### PR TITLE
Fix permissions for basic users accessing profiles

### DIFF
--- a/lib/middleware/user.js
+++ b/lib/middleware/user.js
@@ -16,7 +16,7 @@ router.use((req, res, next) => {
       if (!profile) {
         throw new UnauthorisedError('No associated profile');
       }
-      req.profile = profile;
+      req.user.profile = profile;
       next();
     })
     .catch(next);

--- a/lib/routers/establishment/projects.js
+++ b/lib/routers/establishment/projects.js
@@ -8,7 +8,7 @@ router.get('/', (req, res, next) => {
   const { limit, offset, search, sort } = req.query;
 
   const projects = Project.scopeToParams({
-    licenceHolderId: req.profile.id,
+    licenceHolderId: req.user.profile.id,
     establishmentId: req.establishment.id,
     search,
     offset,
@@ -46,7 +46,7 @@ router.get('/:id', (req, res, next) => {
   const project = Project.scopeSingle({
     id: req.params.id,
     establishmentId: req.establishment.id,
-    licenceHolderId: req.profile.id
+    licenceHolderId: req.user.profile.id
   });
 
   Promise.resolve()

--- a/lib/routers/profile/index.js
+++ b/lib/routers/profile/index.js
@@ -27,7 +27,7 @@ const validate = () => {
   return (req, res, next) => {
     const ignoredFields = ['comments'];
     return validateSchema(req.models.Profile, {
-      ...(req.profile || {}),
+      ...(req.user.profile || {}),
       ...omit(req.body, ignoredFields)
     })(req, res, next);
   };
@@ -40,12 +40,12 @@ const getSingleProfile = req => {
   const { Profile } = req.models;
   const profile = Profile.scopeSingle({
     id: req.profileId,
-    profileId: req.profile.id,
+    userId: req.user.profile.id,
     establishmentId: (req.establishment && req.establishment.id) || undefined
   });
 
   // own profile
-  if (req.profileId === req.profile.id) {
+  if (req.profileId === req.user.profile.id) {
     return profile.get();
   }
 
@@ -78,7 +78,7 @@ const getAllProfiles = req => {
 
   const profiles = Profile.scopeToParams({
     establishmentId: (req.establishment && req.establishment.id) || undefined,
-    profileId: req.profile.id,
+    userId: req.user.profile.id,
     search,
     limit,
     offset,

--- a/lib/routers/profile/pil.js
+++ b/lib/routers/profile/pil.js
@@ -13,7 +13,7 @@ const submit = (action) => {
       data: {
         ...req.body,
         establishmentId: req.establishment.id,
-        profileId: req.profile.id
+        profileId: req.user.profile.id
       },
       id: res.pil && res.pil.id
     };
@@ -31,7 +31,7 @@ const validate = (req, res, next) => {
   return validateSchema(req.models.PIL, {
     ...(res.pil || {}),
     establishmentId: req.establishment.id,
-    profileId: req.profile.id
+    profileId: req.user.profile.id
   })(req, res, next);
 };
 

--- a/lib/routers/profile/training-modules.js
+++ b/lib/routers/profile/training-modules.js
@@ -28,7 +28,7 @@ const validateSchema = () => {
   return (req, res, next) => {
     const validate = data => {
       data = {
-        profileId: req.profile.id,
+        profileId: req.user.profile.id,
         ...data
       };
       if (res.module) {

--- a/lib/routers/user.js
+++ b/lib/routers/user.js
@@ -3,7 +3,7 @@ const { Router } = require('express');
 const router = Router();
 
 router.use((req, res, next) => {
-  req.profileId = req.profile.id;
+  req.profileId = req.user.profile.id;
   next();
 });
 

--- a/lib/workflow/client.js
+++ b/lib/workflow/client.js
@@ -18,7 +18,7 @@ module.exports = settings => {
           return validate(data);
         })
         .then(() => {
-          return submit('/', { body: JSON.stringify({ ...data, changedBy: req.profile.id }) });
+          return submit('/', { body: JSON.stringify({ ...data, changedBy: req.user.profile.id }) });
         });
     };
 

--- a/test/data/default.js
+++ b/test/data/default.js
@@ -23,6 +23,7 @@ module.exports = models => {
         },
         {
           id: 'b2b8315b-82c0-4b2d-bc13-eb13e605ee88',
+          userId: 'basic',
           title: 'Dr',
           firstName: 'Noddy',
           lastName: 'Holder',


### PR DESCRIPTION
The parameters being passed to the schema query scoping functions didn't match the parameters that were expected.

Also moved `req.profile` to `req.user.profile` for consistency with other services which have the current user's profile there, and avoid ambiguity with `req.profileId`, which refers to the profile being queried.