### PR TITLE
Prevent api from crashing if redis is not present

### DIFF
--- a/lib/middleware/rate-limiter/index.js
+++ b/lib/middleware/rate-limiter/index.js
@@ -5,6 +5,7 @@ const limiter = require('./express-limiter');
 
 module.exports = settings => {
   const client = redis.createClient(settings.redis);
+  client.on('error', e => console.error(e.message));
 
   return limiter(client)({
     lookup: ['user.id'],


### PR DESCRIPTION
Currently the order of deployments means that the API gets deployed _before_ redis, and because it then can't find redis it goes into a crash loop, and the deployment never gets past that point.

By allowing the API to run, and attempt to reconnect to redis then the deployment can be successful, and then when redis appears it will connect.