### PR TITLE
Return a 404 if invitation cannot be found in database

### DIFF
--- a/lib/routers/invitation/index.js
+++ b/lib/routers/invitation/index.js
@@ -1,4 +1,5 @@
 const { Router } = require('express');
+const { NotFoundError } = require('../../errors');
 
 const router = Router({ mergeParams: true });
 
@@ -23,6 +24,9 @@ router.param('token', (req, res, next, token) => {
   Invitation.query().where({ token: req.params.token })
     .then(result => result[0])
     .then(invitation => {
+      if (!invitation) {
+        throw new NotFoundError();
+      }
       req.invitation = invitation;
       next();
     })

--- a/test/specs/invitation.js
+++ b/test/specs/invitation.js
@@ -1,0 +1,32 @@
+const assert = require('assert');
+const request = require('supertest');
+const apiHelper = require('../helpers/api');
+
+describe('/invitation', () => {
+  before(() => {
+    return apiHelper.create()
+      .then((api) => {
+        this.api = api.api;
+        this.workflow = api.workflow;
+      });
+  });
+
+  after(() => {
+    return apiHelper.destroy();
+  });
+
+  beforeEach(() => {
+    // reset user for each test
+    this.api.setUser();
+  });
+
+  it('returns a 404 if no invitation is found', () => {
+    return request(this.api)
+      .get('/invitation/not-a-token')
+      .expect(404)
+      .expect(response => {
+        assert.equal(response.body.message, 'Not found');
+      });
+  });
+
+});


### PR DESCRIPTION
Currently we assume there is an invitation found, continue and then throw an error later when we can't access properties of the non-existent invitation.

Instead throw a 404 for a _slightly_ better upstream error handling.