### PR TITLE
Reorder user and workflow middleware

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -29,9 +29,9 @@ module.exports = settings => {
     next();
   });
 
-  app.use(require('./middleware/user'));
-
   app.use(workflow(settings));
+
+  app.use(require('./middleware/user'));
 
   app.use('/me', require('./routers/user'));
   app.use('/invitation', require('./routers/invitation'));


### PR DESCRIPTION
The user middleware requires the workflow middleware to have been mounted or it fails when trying to create new profiles.