### PR TITLE
Allow the user profile to be set in subsequent middleware

### DIFF
--- a/lib/workflow/client.js
+++ b/lib/workflow/client.js
@@ -3,14 +3,18 @@ const { MissingParamError } = require('../errors');
 
 class Workflow {
   // eslint-disable-next-line camelcase
-  constructor(settings, { access_token, profile }) {
+  constructor(settings, user) {
     const headers = {
       // eslint-disable-next-line camelcase
-      Authorization: `bearer ${access_token}`,
+      Authorization: `bearer ${user.access_token}`,
       'Content-type': 'application/json'
     };
     Object.defineProperty(this, 'client', { value: ApiClient(settings, { headers }) });
-    Object.defineProperty(this, 'profile', { value: profile || {} });
+    Object.defineProperty(this, 'profile', {
+      get() {
+        return user.profile;
+      }
+    });
   }
 
   validate(data, ...params) {


### PR DESCRIPTION
Load the user profile dynamically at request-time rather than requiring it to exist at initialisation time.