### PR TITLE
Don't fall over for undefined user

### DIFF
--- a/lib/workflow/client.js
+++ b/lib/workflow/client.js
@@ -12,7 +12,7 @@ class Workflow {
     Object.defineProperty(this, 'client', { value: ApiClient(settings, { headers }) });
     Object.defineProperty(this, 'profile', {
       get() {
-        return user.profile;
+        return user.profile || {};
       }
     });
   }


### PR DESCRIPTION
If a brand new user logs in then we go and create a new profile with no `createdBy` param. We need to handle the case where there is no profile.