### PR TITLE
Set `id` param on workflow submission for invitation acceptance

### DIFF
--- a/lib/routers/invitation/index.js
+++ b/lib/routers/invitation/index.js
@@ -3,21 +3,6 @@ const { NotFoundError } = require('../../errors');
 
 const router = Router({ mergeParams: true });
 
-const accept = (req, res, next) => {
-  const params = {
-    action: 'accept',
-    model: 'invitation',
-    data: req.body.data || req.body,
-    meta: req.body.meta
-  };
-  req.workflow.update(params)
-    .then(response => {
-      res.response = response;
-      next();
-    })
-    .catch(next);
-};
-
 router.param('token', (req, res, next, token) => {
   const { Invitation } = req.models;
   Invitation.query().where({ token: req.params.token })
@@ -44,11 +29,21 @@ router.get('/:token', (req, res, next) => {
 });
 
 router.put('/:token', (req, res, next) => {
-  req.body = {
+  const params = {
+    action: 'accept',
+    model: 'invitation',
     id: req.invitation.id,
-    profileId: req.user.profile.id
+    data: {
+      id: req.invitation.id,
+      profileId: req.user.profile.id
+    }
   };
-  next();
-}, accept);
+  req.workflow.update(params)
+    .then(response => {
+      res.response = response;
+      next();
+    })
+    .catch(next);
+});
 
 module.exports = router;

--- a/lib/workflow/client.js
+++ b/lib/workflow/client.js
@@ -48,7 +48,7 @@ class Workflow {
 
   update(params) {
     this.validate(params, 'id', 'model');
-    const { data = {}, meta = {}, model, id } = params;
+    const { data = {}, meta = {}, model, id, action } = params;
     return this.client('/', {
       method: 'POST',
       json: this._pack({
@@ -56,7 +56,7 @@ class Workflow {
         meta,
         model,
         id,
-        action: 'update'
+        action: action || 'update'
       })
     });
   }


### PR DESCRIPTION
The worflow client requires an id on all `update` calls, so is rejecting these.

Additionally removes a little of the misdirection in the code up to a middleware at the top of the file.