### PR TITLE
Don't wrap the status change comment in a meta prop

### DIFF
--- a/lib/routers/task/index.js
+++ b/lib/routers/task/index.js
@@ -21,7 +21,7 @@ router.get('/:taskId', (req, res, next) => {
 });
 
 router.put('/:taskId/status', (req, res, next) => {
-  return req.workflow.task(req.taskId).status({ status: req.body.status, meta: req.body })
+  return req.workflow.task(req.taskId).status(req.body)
     .then(response => {
       res.response = response;
       next();

--- a/lib/workflow/client.js
+++ b/lib/workflow/client.js
@@ -78,13 +78,13 @@ class Workflow {
   task(taskId) {
     return {
       read: () => this.client(`/${taskId}`),
-      status: ({ status, meta }) => {
+      status: ({ status, comment }) => {
         this.validate({ status, taskId }, 'status', 'taskId');
         return this.client(`/${taskId}/status`, {
           method: 'PUT',
           json: this._pack({
             status,
-            meta
+            comment
           })
         });
       }


### PR DESCRIPTION
Workflow / Taskflow is just expecting a payload with `status` and `comment` properties, so wrapping them in a `meta` prop breaks the validation that looks for a comment when required.

see:
https://github.com/UKHomeOffice/taskflow/blob/65486ad78a28ccd178d59c7d402e855676e35e67/lib/router/case.js#L29
https://github.com/UKHomeOffice/asl-workflow/blob/b435825ad8780d006920f5f188fdfbf217330ee9/lib/hooks/validate/payload.js#L9

