### PR TITLE
Whitelist API payloads

### DIFF
--- a/lib/errors/bad-request.js
+++ b/lib/errors/bad-request.js
@@ -1,0 +1,11 @@
+class BadRequestError extends Error {
+  constructor(msg) {
+    super(msg || 'Bad request');
+  }
+
+  get status() {
+    return 400;
+  }
+}
+
+module.exports = BadRequestError;

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -1,4 +1,5 @@
 module.exports = {
+  BadRequestError: require('./bad-request'),
   NotFoundError: require('./not-found'),
   RateLimitedError: require('./rate-limited'),
   UnauthorisedError: require('./unauthorised'),

--- a/lib/middleware/index.js
+++ b/lib/middleware/index.js
@@ -1,4 +1,5 @@
 module.exports = {
   permissions: require('./permissions'),
+  whitelist: require('./whitelist'),
   validateSchema: require('./validate-schema')
 };

--- a/lib/middleware/whitelist.js
+++ b/lib/middleware/whitelist.js
@@ -1,0 +1,9 @@
+const { BadRequestError } = require('../errors');
+
+module.exports = (...fields) => (req, res, next) => {
+  const disallowed = Object.keys(req.body.data || {}).filter(key => !fields.includes(key));
+  if (disallowed.length) {
+    return next(new BadRequestError(`Invalid parameters: ${disallowed.join()}`));
+  }
+  next();
+};

--- a/lib/routers/establishment/invite-user.js
+++ b/lib/routers/establishment/invite-user.js
@@ -1,6 +1,5 @@
 const { Router } = require('express');
-const permissions = require('../../middleware/permissions');
-const validateSchema = require('../../middleware/validate-schema');
+const { permissions, validateSchema, whitelist } = require('../../middleware');
 
 const router = Router({ mergeParams: true });
 
@@ -8,7 +7,7 @@ const create = (req, res, next) => {
   const params = {
     model: 'invitation',
     data: {
-      ...(req.body.data || req.body),
+      ...req.body.data,
       establishmentId: req.establishment.id
     }
   };
@@ -23,14 +22,15 @@ const create = (req, res, next) => {
 const validateInvitation = (req, res, next) => {
   return validateSchema(req.models.Invitation, {
     token: 'abc123',
-    email: req.body.email,
+    email: req.body.data.email,
     establishmentId: req.establishment.id,
-    role: req.body.role
+    role: req.body.data.role
   })(req, res, next);
 };
 
 router.post('/',
   permissions('profile.invite'),
+  whitelist('email', 'role', 'firstName', 'lastName'),
   validateInvitation,
   create
 );

--- a/lib/routers/establishment/places.js
+++ b/lib/routers/establishment/places.js
@@ -95,7 +95,7 @@ router.get('/', (req, res, next) => {
 
 router.post('/',
   permissions('place.create'),
-  whitelist('site', 'area', 'name', 'suitability', 'holding', 'nacwoId'),
+  whitelist('site', 'area', 'name', 'suitability', 'holding', 'nacwo'),
   validatePlace,
   submit('create')
 );
@@ -107,7 +107,7 @@ router.get('/:id', (req, res, next) => {
 
 router.put('/:id',
   permissions('place.update'),
-  whitelist('site', 'area', 'name', 'suitability', 'holding', 'nacwoId'),
+  whitelist('site', 'area', 'name', 'suitability', 'holding', 'nacwo'),
   validatePlace,
   submit('update')
 );

--- a/lib/routers/establishment/places.js
+++ b/lib/routers/establishment/places.js
@@ -1,8 +1,7 @@
 const { Router } = require('express');
 const isUUID = require('uuid-validate');
 const { NotFoundError } = require('../../errors');
-const permissions = require('../../middleware/permissions');
-const validateSchema = require('../../middleware/validate-schema');
+const { permissions, validateSchema, whitelist } = require('../../middleware');
 
 const submit = action => (req, res, next) => {
   const params = {
@@ -96,6 +95,7 @@ router.get('/', (req, res, next) => {
 
 router.post('/',
   permissions('place.create'),
+  whitelist('site', 'area', 'name', 'suitability', 'holding', 'nacwoId'),
   validatePlace,
   submit('create')
 );
@@ -107,10 +107,15 @@ router.get('/:id', (req, res, next) => {
 
 router.put('/:id',
   permissions('place.update'),
+  whitelist('site', 'area', 'name', 'suitability', 'holding', 'nacwoId'),
   validatePlace,
   submit('update')
 );
 
-router.delete('/:id', permissions('place.delete'), submit('delete'));
+router.delete('/:id',
+  whitelist(),
+  permissions('place.delete'),
+  submit('delete')
+);
 
 module.exports = router;

--- a/lib/routers/profile/certificates.js
+++ b/lib/routers/profile/certificates.js
@@ -10,7 +10,7 @@ const submit = action => (req, res, next) => {
     model: 'certificate',
     meta: req.body.meta,
     data: {
-      ...(req.body.data || req.body),
+      ...req.body.data,
       profileId: req.profileId
     }
   };
@@ -36,7 +36,7 @@ const submit = action => (req, res, next) => {
 
 const validateCertificate = () => (req, res, next) => {
   return validateSchema(req.models.Certificate, {
-    ...req.body,
+    ...req.body.data,
     profileId: req.profileId
   })(req, res, next);
 };

--- a/lib/routers/profile/exemptions.js
+++ b/lib/routers/profile/exemptions.js
@@ -5,7 +5,7 @@ const submit = action => (req, res, next) => {
   const params = {
     model: 'exemption',
     data: {
-      ...(req.body.data || req.body),
+      ...req.body.data,
       profileId: req.profileId
     },
     meta: req.body.meta
@@ -32,7 +32,7 @@ const submit = action => (req, res, next) => {
 
 const validateExemption = () => (req, res, next) => {
   return validateSchema(req.models.Exemption, {
-    ...req.body,
+    ...req.body.data,
     profileId: req.profileId
   })(req, res, next);
 };

--- a/lib/routers/profile/permission.js
+++ b/lib/routers/profile/permission.js
@@ -1,11 +1,15 @@
 const { Router } = require('express');
+const { permissions, whitelist } = require('../../middleware');
 
 const submit = (action) => {
 
   return (req, res, next) => {
     const params = {
       model: 'permissions',
-      data: req.body.data || req.body,
+      data: {
+        ...req.body.data,
+        establishmentId: req.establishment.id
+      },
       id: req.profileId
     };
 
@@ -28,8 +32,16 @@ const submit = (action) => {
 
 const router = Router({ mergeParams: true });
 
-router.put('/', submit('update'));
+router.put('/',
+  permissions('profile.permissions'),
+  whitelist('role'),
+  submit('update')
+);
 
-router.delete('/', submit('delete'));
+router.delete('/',
+  permissions('profile.permissions'),
+  whitelist(),
+  submit('delete')
+);
 
 module.exports = router;

--- a/lib/routers/profile/permission.js
+++ b/lib/routers/profile/permission.js
@@ -8,6 +8,7 @@ const submit = (action) => {
       model: 'permissions',
       data: {
         ...req.body.data,
+        profileId: req.profileId,
         establishmentId: req.establishment.id
       },
       id: req.profileId

--- a/lib/routers/profile/person.js
+++ b/lib/routers/profile/person.js
@@ -1,15 +1,13 @@
-const { omit } = require('lodash');
 const { Router } = require('express');
 const isUUID = require('uuid-validate');
-const { permissions } = require('../../middleware');
-const { validateSchema } = require('../../middleware');
+const { permissions, whitelist, validateSchema } = require('../../middleware');
 const { NotFoundError } = require('../../errors');
 
 const update = () => (req, res, next) => {
   const params = {
     model: 'profile',
     id: req.profileId,
-    data: req.body.data || req.body,
+    data: req.body.data,
     meta: req.body.meta
   };
 
@@ -23,10 +21,9 @@ const update = () => (req, res, next) => {
 
 const validate = () => {
   return (req, res, next) => {
-    const ignoredFields = ['comments'];
     return validateSchema(req.models.Profile, {
       ...(req.user.profile || {}),
-      ...omit(req.body, ignoredFields)
+      ...req.body.data
     })(req, res, next);
   };
 };
@@ -84,6 +81,7 @@ router.get('/', (req, res, next) => {
 
 router.put('/',
   permissions('profile.update', req => ({ id: req.profileId })),
+  whitelist('firstName', 'lastName', 'dob', 'telephone'),
   validate(),
   update()
 );

--- a/lib/routers/profile/pil.js
+++ b/lib/routers/profile/pil.js
@@ -1,5 +1,5 @@
 const { NotFoundError } = require('../../errors');
-const { permissions, validateSchema } = require('../../middleware');
+const { permissions, validateSchema, whitelist } = require('../../middleware');
 const isUUID = require('uuid-validate');
 const { Router } = require('express');
 const { UnrecognisedActionError } = require('../../errors');
@@ -9,7 +9,7 @@ const router = Router({ mergeParams: true });
 const submit = action => (req, res, next) => {
   const params = {
     data: {
-      ...(req.body.data || req.body),
+      ...req.body.data,
       establishmentId: req.establishment.id,
       profileId: req.profileId
     },
@@ -88,12 +88,14 @@ router.get('/:pil', (req, res, next) => {
 
 router.post('/',
   permissions('pil.create'),
+  whitelist(),
   validate,
   submit('create')
 );
 
 router.put('/:pil/:action',
   permissions('pil.update'),
+  whitelist(),
   validateAction,
   validate,
   submit()
@@ -101,10 +103,15 @@ router.put('/:pil/:action',
 
 router.put('/:pil',
   permissions('pil.update'),
+  whitelist('procedures', 'notesCatD', 'notesCatF'),
   validate,
   submit('update')
 );
 
-router.delete('/:pil', permissions('pil.delete'), submit('delete'));
+router.delete('/:pil',
+  whitelist(),
+  permissions('pil.delete'),
+  submit('delete')
+);
 
 module.exports = router;

--- a/test/specs/certificates.js
+++ b/test/specs/certificates.js
@@ -38,7 +38,7 @@ describe('Certificates', () => {
 
     return request(this.api)
       .post(`/establishment/${ESTABSLISHMENT_ID}/profile/${PROFILE_ID}/certificate`)
-      .send(input)
+      .send({ data: input })
       .expect(200)
       .expect(() => {
         assert.equal(this.workflow.handler.callCount, 1);

--- a/test/specs/invite-user.js
+++ b/test/specs/invite-user.js
@@ -24,7 +24,7 @@ describe('Invite User', () => {
     };
     return request(this.api)
       .post('/establishment/100/invite-user')
-      .send(input)
+      .send({ data: input })
       .expect(200)
       .expect(() => {
         assert.equal(this.workflow.handler.callCount, 1);
@@ -45,7 +45,7 @@ describe('Invite User', () => {
     };
     return request(this.api)
       .post('/establishment/100/invite-user')
-      .send(input)
+      .send({ data: input })
       .expect(400)
       .expect(response => {
         assert(
@@ -63,7 +63,7 @@ describe('Invite User', () => {
     };
     return request(this.api)
       .post('/establishment/100/invite-user')
-      .send(input)
+      .send({ data: input })
       .expect(400)
       .expect(response => {
         assert(

--- a/test/specs/pils.js
+++ b/test/specs/pils.js
@@ -23,13 +23,9 @@ describe('/pils', () => {
 
   describe('/pil', () => {
     it('sends a message to workflow on POST', () => {
-      const input = {
-        licenceNumber: 'AB-123',
-        procedures: ['A', 'B']
-      };
       return request(this.api)
         .post(`/establishment/100/profile/${PROFILE_1}/pil`)
-        .send(input)
+        .send({ data: {} })
         .expect(200)
         .expect(() => {
           assert.equal(this.workflow.handler.callCount, 1);
@@ -39,11 +35,20 @@ describe('/pils', () => {
           assert.equal(body.model, 'pil');
           assert.equal(body.action, 'create');
           assert.deepEqual(body.data, {
-            ...input,
             establishmentId: '100',
             profileId: PROFILE_1
           });
         });
+    });
+
+    it('throws a 400 error if extra parameters are sent', () => {
+      const input = {
+        status: 'active'
+      };
+      return request(this.api)
+        .post(`/establishment/100/profile/${PROFILE_1}/pil`)
+        .send({ data: input })
+        .expect(400);
     });
   });
 
@@ -76,7 +81,7 @@ describe('/pils', () => {
       };
       return request(this.api)
         .put(`/establishment/100/profile/${PROFILE_1}/pil/${PIL_1}`)
-        .send(input)
+        .send({ data: input })
         .expect(200)
         .expect(() => {
           assert.equal(this.workflow.handler.callCount, 1);
@@ -93,6 +98,17 @@ describe('/pils', () => {
             procedures: ['C']
           });
         });
+    });
+
+    it('throws a 400 error if extra parameters are sent', () => {
+      const input = {
+        procedures: ['C'],
+        status: 'active'
+      };
+      return request(this.api)
+        .put(`/establishment/100/profile/${PROFILE_1}/pil/${PIL_1}`)
+        .send({ data: input })
+        .expect(400);
     });
 
   });

--- a/test/specs/user.js
+++ b/test/specs/user.js
@@ -63,7 +63,7 @@ describe('/me', () => {
 
     return request(this.api)
       .put('/me')
-      .send(input)
+      .send({ data: input })
       .expect(200)
       .expect(() => {
         assert.equal(this.workflow.handler.callCount, 1);
@@ -74,5 +74,17 @@ describe('/me', () => {
         assert.equal(body.action, 'update');
         assert.deepEqual(body.data, input);
       });
+  });
+
+  it('throws a 400 error if sent invalid parameters', () => {
+    const data = {
+      asruUser: true,
+      firstName: 'Sterling'
+    };
+
+    return request(this.api)
+      .put('/me')
+      .send({ data })
+      .expect(400);
   });
 });


### PR DESCRIPTION
Add a middleware that checks the properties included on the request body, and throws an error if any unexpected parameters are present. 

This allows the API to ensure that not _all_ properties on a database record are editable, and only allowed editable properties can be amended on `PUT`/`POST` calls.

This will be a big breaking change because it also standardises on `req.body.data` for all API calls.