### PR TITLE
Refactor profile router

### DIFF
--- a/lib/middleware/permissions.js
+++ b/lib/middleware/permissions.js
@@ -1,7 +1,8 @@
+const { noop } = require('lodash');
 const { UnauthorisedError } = require('../errors');
 
-module.exports = task => (req, res, next) => {
-  req.user.can(task, req.params)
+module.exports = (task, params = noop) => (req, res, next) => {
+  req.user.can(task, { ...req.params, ...params(req) })
     .then(can => can ? next() : next(new UnauthorisedError()))
     .catch(next);
 };

--- a/lib/routers/establishment/index.js
+++ b/lib/routers/establishment/index.js
@@ -59,10 +59,6 @@ router.get('/:establishment', (req, res, next) => {
 router.use('/:establishment/roles', require('./roles'));
 router.use('/:establishment/place(s)?', require('./places'));
 
-router.use('/:establishment/profile(s)?/:profileId', (req, res, next) => {
-  req.profileId = req.params.profileId;
-  next();
-});
 router.use('/:establishment/profile(s)?', require('../profile'));
 
 router.use('/:establishment/project(s)?', require('./projects'));

--- a/lib/routers/profile/person.js
+++ b/lib/routers/profile/person.js
@@ -83,7 +83,7 @@ router.get('/', (req, res, next) => {
 });
 
 router.put('/',
-  permissions('profile.update'),
+  permissions('profile.update', req => ({ id: req.profileId })),
   validate(),
   update()
 );

--- a/lib/routers/profile/person.js
+++ b/lib/routers/profile/person.js
@@ -1,0 +1,91 @@
+const { omit } = require('lodash');
+const { Router } = require('express');
+const isUUID = require('uuid-validate');
+const { permissions } = require('../../middleware');
+const { validateSchema } = require('../../middleware');
+const { NotFoundError } = require('../../errors');
+
+const update = () => (req, res, next) => {
+  const params = {
+    model: 'profile',
+    id: req.profileId,
+    data: req.body.data || req.body,
+    meta: req.body.meta
+  };
+
+  req.workflow.update(params)
+    .then(response => {
+      res.response = response;
+      next();
+    })
+    .catch(next);
+};
+
+const validate = () => {
+  return (req, res, next) => {
+    const ignoredFields = ['comments'];
+    return validateSchema(req.models.Profile, {
+      ...(req.user.profile || {}),
+      ...omit(req.body, ignoredFields)
+    })(req, res, next);
+  };
+};
+
+const getSingleProfile = req => {
+  if (!isUUID(req.profileId)) {
+    throw new NotFoundError();
+  }
+  const { Profile } = req.models;
+  const profile = Profile.scopeSingle({
+    id: req.profileId,
+    userId: req.user.profile.id,
+    establishmentId: (req.establishment && req.establishment.id) || undefined
+  });
+
+  // own profile
+  if (req.profileId === req.user.profile.id) {
+    return profile.get();
+  }
+
+  return Promise.resolve()
+    .then(() => req.user.can('profile.read.all', req.params))
+    .then(allowed => {
+      if (allowed) {
+        return profile.get();
+      }
+      return Promise.resolve()
+        .then(() => req.user.can('profile.read.basic', req.params))
+        .then(allowed => {
+          if (allowed) {
+            return profile.getNamed();
+          }
+          throw new NotFoundError();
+        });
+    })
+    .then(profile => {
+      if (!profile) {
+        throw new NotFoundError();
+      }
+      return profile;
+    });
+};
+
+const router = Router({ mergeParams: true });
+
+router.get('/', (req, res, next) => {
+  Promise.resolve()
+    .then(() => getSingleProfile(req))
+    .then(profile => {
+      res.response = profile;
+      next();
+    })
+    .catch(next);
+});
+
+router.put('/',
+  permissions('profile.update'),
+  validate(),
+  update()
+);
+
+module.exports = router;

--- a/lib/routers/user.js
+++ b/lib/routers/user.js
@@ -3,11 +3,6 @@ const { Router } = require('express');
 const router = Router();
 
 router.use((req, res, next) => {
-  req.profileId = req.user.profile.id;
-  next();
-});
-
-router.use((req, res, next) => {
   Promise.resolve()
     .then(() => req.user.allowedActions())
     .then(allowedActions => {
@@ -17,7 +12,12 @@ router.use((req, res, next) => {
     .catch(next);
 });
 
-router.use(require('./profile'));
+router.use((req, res, next) => {
+  req.profileId = req.user.profile.id;
+  next();
+});
+
+router.use(require('./profile/person'));
 
 router.use((req, res, next) => {
   const { Invitation } = req.models;


### PR DESCRIPTION
There was some funkiness with the profile router because it was _sometimes_ mounted into a place with an id, and sometimes not. So sometimes a request to `/` was a list, and sometimes it was for the logged in user's profile.

This made attaching actions to that route needlessly hard, so split the common bits out, and then mount those in both places, with more appropriate logic.