### PR TITLE
Add search profiles (unscoped) router

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -38,6 +38,10 @@ module.exports = settings => {
   app.use('/establishment(s)?', require('./routers/establishment'));
   app.use('/task(s)?', require('./routers/task'));
 
+  app.use('/search/profile(s)?', require('./routers/search/profile'));
+  // app.use('/all/establishments(s)?', require('./routers/unscoped/establishment'));
+  // app.use('/all/projects(s)?', require('./routers/unscoped/project'));
+
   app.use((req, res, next) => {
     if (res.response) {
       const response = {

--- a/lib/routers/search/profile.js
+++ b/lib/routers/search/profile.js
@@ -3,6 +3,48 @@ const { NotFoundError } = require('../../errors');
 
 const router = Router({ mergeParams: true });
 
+const getFilterOptions = (Profile, { query }) => {
+  query = query || Profile.query();
+  return query;
+};
+
+const count = (Profile, { query }) => {
+  query = query || Profile.query();
+  return query.count().then(result => result[0].count);
+};
+
+const searchAndFilter = (Profile, {
+  query,
+  search,
+  filters = {},
+  limit,
+  offset,
+  sort = {}
+}) => {
+  query = query || Profile.query();
+
+  query
+    .distinct('profiles.*')
+    .leftJoinRelation('[pil, projects]')
+    .eager('[pil, projects, establishments]')
+    .where(builder => {
+      if (search) {
+        return builder
+          .orWhere(builder => Profile.searchFullName({ search, query: builder }));
+      }
+    });
+
+  query = Profile.paginate({ query, limit, offset });
+
+  if (sort.column) {
+    query = Profile.orderBy({ query, sort });
+  } else {
+    query.orderBy('lastName');
+  }
+
+  return query;
+};
+
 const getAllProfiles = req => {
   const { Profile } = req.models;
   const { search, sort, filters, limit, offset } = req.query;
@@ -20,7 +62,11 @@ const getAllProfiles = req => {
     .then(() => req.user.can('profile.read.all', req.params))
     .then(allowed => {
       if (allowed) {
-        return Profile.getProfilesUnscoped(params);
+        return Promise.all([
+          getFilterOptions(Profile, params),
+          count(Profile, params),
+          searchAndFilter(Profile, params)
+        ]).then(([filters, total, profiles]) => ({ filters, total, profiles }));
       }
       throw new NotFoundError();
     });

--- a/lib/routers/search/profile.js
+++ b/lib/routers/search/profile.js
@@ -1,0 +1,42 @@
+const { Router } = require('express');
+const { NotFoundError } = require('../../errors');
+
+const router = Router({ mergeParams: true });
+
+const getAllProfiles = req => {
+  const { Profile } = req.models;
+  const { search, sort, filters, limit, offset } = req.query;
+
+  const params = {
+    userId: req.user.profile.id,
+    search,
+    limit,
+    offset,
+    sort,
+    filters
+  };
+
+  return Promise.resolve()
+    .then(() => req.user.can('profile.read.all', req.params))
+    .then(allowed => {
+      if (allowed) {
+        return Profile.getProfilesUnscoped(params);
+      }
+      throw new NotFoundError();
+    });
+};
+
+router.get('/', (req, res, next) => {
+  Promise.resolve()
+    .then(() => getAllProfiles(req))
+    .then(({ filters, total, profiles }) => {
+      res.meta.filters = filters;
+      res.meta.total = total;
+      res.meta.count = profiles.total;
+      res.response = profiles.results;
+      next();
+    })
+    .catch(next);
+});
+
+module.exports = router;


### PR DESCRIPTION
Provides an unscoped endpoint for searching profiles.

The intention is to eventually move this to `asl-inspector-ui`.