### PR TITLE
Respond with worflow response

### DIFF
--- a/lib/routers/profile/person.js
+++ b/lib/routers/profile/person.js
@@ -13,7 +13,7 @@ const update = () => (req, res, next) => {
 
   req.workflow.update(params)
     .then(response => {
-      res.response = response;
+      res.response = response.json.data;
       next();
     })
     .catch(next);


### PR DESCRIPTION
Strips out redundant layers of `json.data.json.data` from the API response.

This makes this call consistent with other places (e.g. task lists) where the response from workflow API calls are returned to the clients.