### PR TITLE
Log complete error objects

### DIFF
--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -3,7 +3,7 @@ module.exports = () => {
   return (error, req, res, next) => {
     error.status = error.status || 500;
     if (typeof req.log === 'function' && error.status > 499) {
-      req.log('error', error);
+      req.log('error', { ...error, stack: error.stack, message: error.message });
     }
     res.status(error.status);
     res.json({ message: error.message });


### PR DESCRIPTION
Some properties of native Error classes are not enumerable so don't appear if you log them. That's annoying.