### PR TITLE
Dont assume a version is submitted

### DIFF
--- a/lib/routers/establishment/projects.js
+++ b/lib/routers/establishment/projects.js
@@ -17,13 +17,6 @@ const submit = action => (req, res, next) => {
     meta: req.body.meta || {}
   };
 
-  if (req.project) {
-    const submitted = req.project.versions.find(v => v.status === 'submitted');
-    if (submitted) {
-      Object.assign(params.meta, { version: submitted.id });
-    }
-  }
-
   return Promise.resolve()
     .then(() => {
       switch (action) {


### PR DESCRIPTION
a grant task used to assume a version has been submitted - this is now not the case. dont assume anything and just use they values given (version id sent in req)