### PR TITLE
Don't use up rate limiting on project updates

### DIFF
--- a/lib/middleware/rate-limiter/index.js
+++ b/lib/middleware/rate-limiter/index.js
@@ -11,7 +11,15 @@ module.exports = settings => {
     lookup: ['user.id'],
     total: settings.limiter.total,
     expire: 1000 * 60 * 60,
-    whitelist: req => req.path === '/me',
+    whitelist: req => {
+      if (req.path === '/me') {
+        return true;
+      }
+      if (req.method === 'PUT' && req.path.match(/\/project-versions\/([a-z0-9-]+)\/(update|patch)$/)) {
+        return true;
+      }
+      return false;
+    },
     ignoreErrors: false,
     onRateLimited: function (req, res, next) {
       next(new RateLimitedError());


### PR DESCRIPTION
Updates to projects come in super quickly, and shouldn't use up part of the rate limiting.