### PR TITLE
Prevent duplicate invites with the same email

### DIFF
--- a/lib/routers/establishment/invite-user.js
+++ b/lib/routers/establishment/invite-user.js
@@ -33,7 +33,7 @@ const preventDuplicateInvite = (req, res, next) => {
     .then(() => {
       return req.models.Profile.query()
         .scopeToEstablishment('establishments.id', req.establishment.id)
-        .where('profiles.email', req.body.data.email)
+        .whereRaw('LOWER(profiles.email) LIKE ?', [req.body.data.email.toLowerCase()])
         .first();
     })
     .then(profile => {

--- a/lib/routers/establishment/invite-user.js
+++ b/lib/routers/establishment/invite-user.js
@@ -33,7 +33,7 @@ const preventDuplicateInvite = (req, res, next) => {
     .then(() => {
       return req.models.Profile.query()
         .scopeToEstablishment('establishments.id', req.establishment.id)
-        .whereRaw('LOWER(profiles.email) LIKE ?', [req.body.data.email.toLowerCase()])
+        .where('profiles.email', 'iLike', req.body.data.email)
         .first();
     })
     .then(profile => {

--- a/lib/routers/user.js
+++ b/lib/routers/user.js
@@ -25,7 +25,7 @@ router.use((req, res, next) => {
   Promise.resolve()
     .then(() => {
       return Invitation.query()
-        .where({ email: req.user.profile.email })
+        .whereRaw('LOWER(email) LIKE ?', [req.user.profile.email.toLowerCase()])
         .eager('establishment(name)', {
           name: builder => builder.select('name')
         });

--- a/lib/routers/user.js
+++ b/lib/routers/user.js
@@ -25,7 +25,7 @@ router.use((req, res, next) => {
   Promise.resolve()
     .then(() => {
       return Invitation.query()
-        .whereRaw('LOWER(email) LIKE ?', [req.user.profile.email.toLowerCase()])
+        .where('email', 'iLike', req.user.profile.email)
         .eager('establishment(name)', {
           name: builder => builder.select('name')
         });

--- a/test/data/default.js
+++ b/test/data/default.js
@@ -220,7 +220,7 @@ module.exports = models => {
         .then(() => {
           return Invitation.query().insertGraph([
             {
-              email: 'test1@example.com',
+              email: 'TEST1@example.com', // test that case does not have to match profile.email
               establishmentId: 101,
               role: 'basic',
               token: 'abcdef'

--- a/test/specs/invite-user.js
+++ b/test/specs/invite-user.js
@@ -72,4 +72,44 @@ describe('Invite User', () => {
         );
       });
   });
+
+  it('rejects with an error if an invite with the same email already exists', () => {
+    const user = {
+      firstName: 'Linford',
+      lastName: 'Christie',
+      email: 'TEST1@example.com',
+      role: 'basic'
+    };
+
+    return request(this.api)
+      .post('/establishment/100/invite-user')
+      .send({ data: user })
+      .expect(400)
+      .expect(response => {
+        assert(
+          JSON.parse(response.error.text).message
+            .match(/This user is already associated/)
+        );
+      });
+  });
+
+  it('rejects with an error if an invite with the same email already exists (case-insensitive)', () => {
+    const user = {
+      firstName: 'Linford',
+      lastName: 'Christie',
+      email: 'TeSt1@ExAmPlE.cOm',
+      role: 'basic'
+    };
+
+    return request(this.api)
+      .post('/establishment/100/invite-user')
+      .send({ data: user })
+      .expect(400)
+      .expect(response => {
+        assert(
+          JSON.parse(response.error.text).message
+            .match(/This user is already associated/)
+        );
+      });
+  });
 });

--- a/test/specs/invite-user.js
+++ b/test/specs/invite-user.js
@@ -73,7 +73,7 @@ describe('Invite User', () => {
       });
   });
 
-  it('rejects with an error if an invite with the same email already exists', () => {
+  it('rejects with an error if a profile with the same email already exists at the establishment', () => {
     const user = {
       firstName: 'Linford',
       lastName: 'Christie',
@@ -93,7 +93,7 @@ describe('Invite User', () => {
       });
   });
 
-  it('rejects with an error if an invite with the same email already exists (case-insensitive)', () => {
+  it('rejects with an error if a profile with the same email already exists at the establishment (case-insensitive)', () => {
     const user = {
       firstName: 'Linford',
       lastName: 'Christie',

--- a/test/specs/user.js
+++ b/test/specs/user.js
@@ -48,7 +48,10 @@ describe('/me', () => {
         .expect(200)
         .expect(response => {
           assert.equal(response.body.data.invitations.length, 1);
-          assert.equal(response.body.data.invitations[0].email, 'test1@example.com');
+
+          // match is case-insensitive but returned email has case preserved
+          assert.equal(response.body.data.invitations[0].email, 'TEST1@example.com');
+
           assert.equal(response.body.data.invitations[0].establishment.name, 'Marvell Pharmaceuticals');
           assert.deepEqual(Object.keys(response.body.data.invitations[0].establishment), ['name']);
         });


### PR DESCRIPTION
Also makes invites case-insensitive (i.e. an invite to JOE.BLOGGS@EXAMPLE.COM will show up when joe.bloggs@example.com is signed in).