### PR TITLE
Map camelCase migrated values onto correct keys

### DIFF
--- a/test/data/default.js
+++ b/test/data/default.js
@@ -1,6 +1,6 @@
 module.exports = models => {
 
-  const { Establishment, Profile, PIL, Invitation } = models;
+  const { Establishment, Profile, PIL, Invitation, Project, ProjectVersion } = models;
 
   return Promise.resolve()
     .then(() => {
@@ -230,6 +230,73 @@ module.exports = models => {
               establishmentId: 101,
               role: 'admin',
               token: 'abcdef'
+            }
+          ]);
+        })
+        .then(() => {
+          return Project.query().insert([
+            {
+              id: 'ba3f4fdf-27e4-461e-a251-111111111111',
+              title: 'Test project',
+              status: 'inactive',
+              establishmentId: 101,
+              schemaVersion: 1
+            },
+            {
+              id: 'ba3f4fdf-27e4-461e-a251-333333333333',
+              title: 'Test legacy project',
+              status: 'inactive',
+              establishmentId: 101,
+              schemaVersion: 0
+            }
+          ]);
+        })
+        .then(() => {
+          return ProjectVersion.query().insert([
+            {
+              projectId: 'ba3f4fdf-27e4-461e-a251-111111111111',
+              id: 'ba3f4fdf-27e4-461e-a251-222222222222',
+              data: {
+                protocols: [
+                  {
+                    species: [
+                      {
+                        geneticallyAltered: true
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              projectId: 'ba3f4fdf-27e4-461e-a251-333333333333',
+              id: 'ba3f4fdf-27e4-461e-a251-444444444444',
+              data: {
+                protocols: [
+                  {
+                    species: [
+                      {
+                        'genetically-altered': true,
+                        lifeStage: 'Adult'
+                      },
+                      {
+                        geneticallyAltered: true,
+                        'genetically-altered': false,
+                        lifeStage: 'Adult'
+                      }
+                    ]
+                  },
+                  {
+                    species: [
+                      {
+                        geneticallyAltered: true,
+                        'life-stages': 'Embryo',
+                        lifeStage: 'Adult'
+                      }
+                    ]
+                  }
+                ]
+              }
             }
           ]);
         });

--- a/test/helpers/db.js
+++ b/test/helpers/db.js
@@ -6,6 +6,7 @@ module.exports = settings => {
     init: (populate) => {
       const schema = Schema(settings);
       const tables = [
+        'ProjectVersion',
         'Project',
         'Permission',
         'Authorisation',

--- a/test/specs/project-versions.js
+++ b/test/specs/project-versions.js
@@ -1,0 +1,53 @@
+const assert = require('assert');
+const request = require('supertest');
+const apiHelper = require('../helpers/api');
+
+describe('/projects', () => {
+  before(() => {
+    return apiHelper.create()
+      .then((api) => {
+        this.api = api.api;
+        this.workflow = api.workflow;
+      });
+  });
+
+  after(() => {
+    return apiHelper.destroy();
+  });
+
+  it('maps cameCase species fields to hyphen-separated - bugfix', () => {
+    return request(this.api)
+      .get('/establishment/101/project/ba3f4fdf-27e4-461e-a251-333333333333/project-version/ba3f4fdf-27e4-461e-a251-444444444444')
+      .expect(200)
+      .expect(response => {
+        const protocols = response.body.data.data.protocols;
+
+        assert.equal(protocols[0].species[0]['genetically-altered'], true, 'Should preserve `genetically-altered` value');
+        assert.equal(protocols[0].species[0]['life-stages'], 'Adult', 'Should map `lifeStage` value to `life-stages`');
+        assert.equal(protocols[0].species[0].lifeStage, undefined, 'Should remove `lifeStage` value');
+
+        assert.equal(protocols[0].species[1]['genetically-altered'], false, 'Should preserve `genetically-altered` value');
+        assert.equal(protocols[0].species[1].geneticallyAltered, undefined, 'Should remove `geneticallyAltered` value');
+        assert.equal(protocols[0].species[1]['life-stages'], 'Adult', 'Should map `lifeStage` value to `life-stages`');
+        assert.equal(protocols[0].species[1].lifeStage, undefined, 'Should remove `lifeStage` value');
+
+        assert.equal(protocols[1].species[0]['genetically-altered'], true, 'Should map `geneticallyAltered` value to `genetically-altered`');
+        assert.equal(protocols[1].species[0].geneticallyAltered, undefined, 'Should remove `geneticallyAltered` value');
+        assert.equal(protocols[1].species[0]['life-stages'], 'Embryo', 'Should preserve `life-stages` value');
+        assert.equal(protocols[1].species[0].lifeStage, undefined, 'Should remove `lifeStage` value');
+      });
+  });
+
+  it('does not map any fields on schema version 1 licences - bugfix', () => {
+    return request(this.api)
+      .get('/establishment/101/project/ba3f4fdf-27e4-461e-a251-111111111111/project-version/ba3f4fdf-27e4-461e-a251-222222222222')
+      .expect(200)
+      .expect(response => {
+        const protocols = response.body.data.data.protocols;
+
+        assert.equal(protocols[0].species[0].geneticallyAltered, true, 'Should preserve `geneticallyAltered` value');
+
+      });
+  });
+
+});


### PR DESCRIPTION
Some properties on protocol -> species were incorrectly mapped to camelCase keys in migration. When reading a project from the API map the values onto the correct keys.