### PR TITLE
Bugfix - normalise steps for legacy

### DIFF
--- a/lib/routers/establishment/project-versions.js
+++ b/lib/routers/establishment/project-versions.js
@@ -32,6 +32,9 @@ const normalise = (version) => {
       delete species.geneticallyAltered;
       delete species.lifeStage;
     });
+    if (Array.isArray(protocol.steps)) {
+      delete protocol.steps;
+    }
   });
   return version;
 };


### PR DESCRIPTION
If protocol steps is an array, it should be removed as this is caused by a bug in the interface