### PR TITLE
Fix establishment scoping of permissions removal

### DIFF
--- a/lib/routers/profile/permission.js
+++ b/lib/routers/profile/permission.js
@@ -25,7 +25,7 @@ const submit = (action) => {
         }
       })
       .then(response => {
-        res.response = response;
+        res.response = {};
         next();
       })
       .catch(next);
@@ -44,13 +44,13 @@ const removable = () => (req, res, next) => {
   const params = {
     id: req.profileId,
     userId: req.user.profile.id,
-    establishmentId: req.establishmentId
+    establishmentId: req.establishment.id
   };
   Profile.scopeSingle(params).get()
     .then(profile => {
       const hasProjects = profile.projects.filter(project => project.status === 'active').length;
       const hasRoles = profile.roles && profile.roles.length;
-      const hasPil = profile.pil && profile.pil.status === 'active' && profile.pil.establishmentId === req.establishmentId;
+      const hasPil = profile.pil && profile.pil.status === 'active' && profile.pil.establishmentId === req.establishment.id;
 
       if (hasProjects || hasRoles || hasPil) {
         throw new BadRequestError();

--- a/test/data/default.js
+++ b/test/data/default.js
@@ -212,7 +212,8 @@ module.exports = models => {
             id: 101,
             profiles: [
               { id: 'ae28fb31-d867-4371-9b4f-79019e71232f' },
-              { id: 'ae28fb31-d867-4371-9b4f-79019e71232e' }
+              { id: 'ae28fb31-d867-4371-9b4f-79019e71232e' },
+              { id: 'a942ffc7-e7ca-4d76-a001-0b5048a057d9' }
             ],
             roles: [
               {

--- a/test/specs/permissions.js
+++ b/test/specs/permissions.js
@@ -1,0 +1,28 @@
+const request = require('supertest');
+const apiHelper = require('../helpers/api');
+
+describe('/permissions', () => {
+  before(() => {
+    return apiHelper.create()
+      .then((api) => {
+        this.api = api.api;
+        this.workflow = api.workflow;
+      });
+  });
+
+  after(() => {
+    return apiHelper.destroy();
+  });
+
+  beforeEach(() => {
+    // reset user for each test
+    this.api.setUser();
+  });
+
+  it('can delete permissions from users who hold roles at other establishments - regression', () => {
+    return request(this.api)
+      .delete('/establishment/101/profile/a942ffc7-e7ca-4d76-a001-0b5048a057d9/permission')
+      .expect(200);
+  });
+
+});


### PR DESCRIPTION
`req.establishmentId` is not set, which prevents the profile being scoped to an establishemnt and so rejects an attempt to remove permissions from a person with roles at other etablishments.

By correctly setting the establishemnt id in the scope call the check for removal of permissions is successful and a person's permissions can be removed.