### PR TITLE
Feature - include est name in PIL

### DIFF
--- a/lib/routers/profile/pil.js
+++ b/lib/routers/profile/pil.js
@@ -68,7 +68,7 @@ const checkEstablishment = (req, res, next) => {
   next();
 };
 
-const attachEstablishmentName = (req, res, next) => {
+const attachEstablishmentDetails = (req, res, next) => {
   const establishmentId = req.pil.establishmentId;
   const { Establishment } = req.models;
   return Promise.resolve()
@@ -76,9 +76,9 @@ const attachEstablishmentName = (req, res, next) => {
     .then(can => {
       if (can) {
         return Promise.resolve()
-          .then(() => Establishment.query().findById(establishmentId).select('name'))
+          .then(() => Establishment.query().findById(establishmentId).select('name', 'address'))
           .then(establishment => {
-            req.pil.establishmentName = establishment.name;
+            req.pil.establishment = establishment;
           });
       }
     })
@@ -116,7 +116,7 @@ router.param('pil', (req, res, next, id) => {
 
 router.get('/:pil',
   permissions('pil.read'),
-  attachEstablishmentName,
+  attachEstablishmentDetails,
   (req, res, next) => {
     res.response = req.pil;
     next();

--- a/lib/routers/profile/pil.js
+++ b/lib/routers/profile/pil.js
@@ -68,6 +68,24 @@ const checkEstablishment = (req, res, next) => {
   next();
 };
 
+const attachEstablishmentName = (req, res, next) => {
+  const establishmentId = req.pil.establishmentId;
+  const { Establishment } = req.models;
+  return Promise.resolve()
+    .then(() => req.user.can('establishment.read', { establishment: req.pil.establishmentId }))
+    .then(can => {
+      if (can) {
+        return Promise.resolve()
+          .then(() => Establishment.query().findById(establishmentId).select('name'))
+          .then(establishment => {
+            req.pil.establishmentName = establishment.name;
+          });
+      }
+    })
+    .then(() => next())
+    .catch(next);
+};
+
 router.param('pil', (req, res, next, id) => {
   if (!isUUID(id)) {
     return next(new NotFoundError());
@@ -98,6 +116,7 @@ router.param('pil', (req, res, next, id) => {
 
 router.get('/:pil',
   permissions('pil.read'),
+  attachEstablishmentName,
   (req, res, next) => {
     res.response = req.pil;
     next();

--- a/test/specs/pils.js
+++ b/test/specs/pils.js
@@ -79,7 +79,7 @@ describe('/pils', () => {
     });
 
     describe('establishmentName permissions', () => {
-      it('includes the establishmentName property if the requesting user has permissions for the holding establishment', () => {
+      it('includes the establishment if the requesting user has permissions for the holding establishment', () => {
         const can = sinon.stub().resolves(true);
         can.withArgs('establishment.read', { establishment: 100 }).resolves(true);
         this.api.setUser({ can });
@@ -87,11 +87,11 @@ describe('/pils', () => {
           .get(`/establishment/101/profile/${PROFILE_1}/pil/${PIL_1}`)
           .expect(200)
           .expect(pil => {
-            assert.equal(pil.body.data.establishmentName, 'University of Croydon');
+            assert.ok(pil.body.data.establishment);
           });
       });
 
-      it('does not include the establishmentName property if the requesting user doesn\'t have permissions for the holding establishment', () => {
+      it('does not include the establishment if the requesting user doesn\'t have permissions for the holding establishment', () => {
         const can = sinon.stub().resolves(true);
         can.withArgs('establishment.read', { establishment: 100 }).resolves(false);
         this.api.setUser({ can });
@@ -99,7 +99,7 @@ describe('/pils', () => {
           .get(`/establishment/101/profile/${PROFILE_1}/pil/${PIL_1}`)
           .expect(200)
           .expect(pil => {
-            assert.equal(pil.body.data.establishmentName, undefined);
+            assert.equal(pil.body.data.establishment, undefined);
           });
       });
     });

--- a/test/specs/pils.js
+++ b/test/specs/pils.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const request = require('supertest');
+const sinon = require('sinon');
 const apiHelper = require('../helpers/api');
 
 const PROFILE_1 = 'f0835b01-00a0-4c7f-954c-13ed2ef7efd9';
@@ -75,6 +76,32 @@ describe('/pils', () => {
         .expect(pil => {
           assert.equal(pil.body.data.licenceNumber, 'AB-123');
         });
+    });
+
+    describe('establishmentName permissions', () => {
+      it('includes the establishmentName property if the requesting user has permissions for the holding establishment', () => {
+        const can = sinon.stub().resolves(true);
+        can.withArgs('establishment.read', { establishment: 100 }).resolves(true);
+        this.api.setUser({ can });
+        return request(this.api)
+          .get(`/establishment/101/profile/${PROFILE_1}/pil/${PIL_1}`)
+          .expect(200)
+          .expect(pil => {
+            assert.equal(pil.body.data.establishmentName, 'University of Croydon');
+          });
+      });
+
+      it('does not include the establishmentName property if the requesting user doesn\'t have permissions for the holding establishment', () => {
+        const can = sinon.stub().resolves(true);
+        can.withArgs('establishment.read', { establishment: 100 }).resolves(false);
+        this.api.setUser({ can });
+        return request(this.api)
+          .get(`/establishment/101/profile/${PROFILE_1}/pil/${PIL_1}`)
+          .expect(200)
+          .expect(pil => {
+            assert.equal(pil.body.data.establishmentName, undefined);
+          });
+      });
     });
 
     describe('grant', () => {


### PR DESCRIPTION
On GET PIL check user can read PIL establishment, if so include the etablishment name in the response