### PR TITLE
Updated project permissions

### DIFF
--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -5,6 +5,9 @@ module.exports = () => {
     if (typeof req.log === 'function' && error.status > 499) {
       req.log('error', { ...error, stack: error.stack, message: error.message });
     }
+    if (req.method === 'GET' && error.status === 403) {
+      res.status = 404;
+    }
     res.status(error.status);
     res.json({ message: error.message });
   };

--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -6,7 +6,7 @@ module.exports = () => {
       req.log('error', { ...error, stack: error.stack, message: error.message });
     }
     if (req.method === 'GET' && error.status === 403) {
-      res.status = 404;
+      error.status = 404;
     }
     res.status(error.status);
     res.json({ message: error.message });

--- a/test/specs/establishments.js
+++ b/test/specs/establishments.js
@@ -27,11 +27,11 @@ describe('/establishments', () => {
       });
   });
 
-  it('returns a 403 id user does not have permission to view all establishments', () => {
+  it('returns a 404 if user does not have permission to view all establishments', () => {
     this.api.setUser({ can: () => Promise.reject(NOT_AUTHORISED) });
     return request(this.api)
       .get('/establishments')
-      .expect(403);
+      .expect(404);
   });
 
   describe('/establishment/:establishment', () => {
@@ -82,11 +82,11 @@ describe('/establishments', () => {
         });
     });
 
-    it('returns a 403 if the user is not authorised', () => {
+    it('returns a 404 if the user is not authorised', () => {
       this.api.setUser({ can: () => Promise.reject(NOT_AUTHORISED) });
       return request(this.api)
         .get('/establishment/100')
-        .expect(403);
+        .expect(404);
     });
 
     describe('grant', () => {


### PR DESCRIPTION
* removed custom permissions implementation - projects permissions are now handled internally in permissions service
* renamed `:id` to `:projectId` in project router - this is the name of the param used in permissions service