### PR TITLE
Rename PIL id parameter in PIL url paths

### DIFF
--- a/lib/routers/profile/pil.js
+++ b/lib/routers/profile/pil.js
@@ -87,7 +87,7 @@ const attachEstablishmentDetails = (req, res, next) => {
     .catch(next);
 };
 
-router.param('pil', (req, res, next, id) => {
+router.param('pilId', (req, res, next, id) => {
   if (!isUUID(id)) {
     return next(new NotFoundError());
   }
@@ -116,7 +116,7 @@ router.param('pil', (req, res, next, id) => {
     .catch(next);
 });
 
-router.get('/:pil',
+router.get('/:pilId',
   permissions('pil.read'),
   attachEstablishmentDetails,
   (req, res, next) => {
@@ -133,26 +133,26 @@ router.post('/',
   submit('create')
 );
 
-router.put('/:pil/:action',
+router.put('/:pilId/:action',
   permissions('pil.update'),
   checkEstablishment,
   validateAction,
   validate
 );
 
-router.put('/:pil/grant',
+router.put('/:pilId/grant',
   whitelist('procedures', 'notesCatD', 'notesCatF', 'species'),
   updateDataAndStatus(),
   submit('grant')
 );
 
-router.put('/:pil/revoke',
+router.put('/:pilId/revoke',
   whitelist('comments'),
   updateDataAndStatus(),
   submit('revoke')
 );
 
-router.put('/:pil/transfer',
+router.put('/:pilId/transfer',
   whitelist('procedures', 'notesCatD', 'notesCatF', 'species', 'establishment'),
   updateDataAndStatus(),
   (req, res, next) => {
@@ -165,7 +165,7 @@ router.put('/:pil/transfer',
   submit('transfer')
 );
 
-router.delete('/:pil',
+router.delete('/:pilId',
   whitelist(),
   permissions('pil.delete'),
   checkEstablishment,


### PR DESCRIPTION
The permissions middleware expects `req.params.pilId` to be set when calling PIL-based permissions, nd other services consistently use `thingId` as parameter names, so modify this for consistency and compatibility with permissions.