### PR TITLE
Handle 403 errors as 404

### DIFF
--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -6,7 +6,8 @@ module.exports = () => {
       req.log('error', { ...error, stack: error.stack, message: error.message });
     }
     if (req.method === 'GET' && error.status === 403) {
-      error.status = 404;
+      res.status(404);
+      return res.json({ message: 'Not found' });
     }
     res.status(error.status);
     res.json({ message: error.message });


### PR DESCRIPTION
`error.status` is a read only property on errors, so setting it does nothing. Handle 403 on GETs explicitly.