### PR TITLE
Hide non-billable PILs from non-ASRU users

### DIFF
--- a/lib/routers/establishment/billing.js
+++ b/lib/routers/establishment/billing.js
@@ -97,8 +97,12 @@ router.get('/pils', (req, res, next) => {
   };
 
   Promise.resolve()
-    .then(() => {
+    .then(() => req.user.can('pil.updateBillable'))
+    .then(canSeeBillable => {
       let query = PIL.query().billable(params);
+      if (!canSeeBillable) {
+        query = query.whereNotWaived();
+      }
       if (filter) {
         query = query.andWhere(builder => {
           builder


### PR DESCRIPTION
Adds a clause to the list of billable pils to ignore non-billable rows where the user does not have permission to see those.