### PR TITLE
Respond with only the year if requesting billing with no year

### DIFF
--- a/lib/routers/establishment/billing.js
+++ b/lib/routers/establishment/billing.js
@@ -35,6 +35,9 @@ router.use((req, res, next) => {
   let year = req.query.year;
   if (!year) {
     year = Object.keys(fees).pop();
+    res.meta.year = year;
+    res.response = {};
+    return next('router');
   }
   if (!fees[year]) {
     return next(new NotFoundError());


### PR DESCRIPTION
All the client does in this context is redirect to the appropriate year, so don't bother loading data that isn't used.