### PR TITLE
Set RA properties on project API responses

### DIFF
--- a/lib/helpers/retrospective-assessment.js
+++ b/lib/helpers/retrospective-assessment.js
@@ -1,0 +1,73 @@
+const {
+  some,
+  intersection,
+  values,
+  flatten,
+  isUndefined,
+  isPlainObject
+} = require('lodash');
+const { projectSpecies } = require('@asl/constants');
+
+const species = flatten(values(projectSpecies));
+
+const nopes = [
+  // legacy
+  'prosimians',
+  'marmosets',
+  'cynomolgus',
+  'rhesus',
+  // legacy
+  'vervets',
+  // legacy
+  'baboons',
+  // legacy
+  'squirrel-monkeys',
+  // legacy
+  'other-old-world',
+  // legacy
+  'other-new-world',
+  'other-nhps',
+  // legacy
+  'apes',
+  'beagles',
+  'other-dogs',
+  'cats',
+  'horses'
+];
+
+function isRequired(project) {
+  if (!project) {
+    return false;
+  }
+  const hasRASpecies = !!intersection(project.species, nopes).length;
+  const hasRASpeciesOther = !!intersection(project['species-other'], nopes.map(n => (species.find(s => s.value === n) || {}).label)).length;
+  const hasEndangeredAnimals = project['endangered-animals'];
+  const hasSevereProtocols = some(project.protocols, p => (p.severity || '').match(/severe/ig));
+  return hasRASpecies || hasRASpeciesOther || hasEndangeredAnimals || hasSevereProtocols;
+}
+
+function hasCondition(project) {
+  if (!project) {
+    return false;
+  }
+  if (!isUndefined(project.retrospectiveAssessment)) {
+    // legacy licences may have an object containing a boolean/
+    if (isPlainObject(project.retrospectiveAssessment)) {
+      return !!project.retrospectiveAssessment['retrospective-assessment-required'];
+    }
+    // now saved as a boolean
+    return !!project.retrospectiveAssessment;
+  }
+  // previous new licences contained a 'retrospective-assessment' condition.
+  if (project.conditions && project.conditions.find(c => c.key === 'retrospective-assessment')) {
+    return true;
+  }
+  return false;
+}
+
+module.exports = function requiresRetrospectiveAssessment(project) {
+  return {
+    required: isRequired(project),
+    condition: hasCondition(project)
+  };
+};

--- a/lib/routers/establishment/project-versions.js
+++ b/lib/routers/establishment/project-versions.js
@@ -2,12 +2,18 @@ const { Router } = require('express');
 const isUUID = require('uuid-validate');
 const { permissions } = require('../../middleware');
 const { NotFoundError, BadRequestError } = require('../../errors');
+const getRetrospectiveAssessment = require('../../helpers/retrospective-assessment');
 
 const perms = task => permissions(task, req => ({ licenceHolderId: req.project.licenceHolderId }));
 
 const router = Router({ mergeParams: true });
 
 const normalise = (version) => {
+  // add RA flags to project version
+  const ra = getRetrospectiveAssessment(version.data);
+  version.retrospectiveAssessment = ra.required || ra.condition;
+  version.retrospectiveAssessmentRequired = ra.required;
+
   if (version.project.schemaVersion !== 0) {
     return version;
   }

--- a/lib/routers/establishment/projects.js
+++ b/lib/routers/establishment/projects.js
@@ -1,7 +1,9 @@
 const { get, some } = require('lodash');
 const { Router } = require('express');
+const moment = require('moment');
 const { BadRequestError, NotFoundError } = require('../../errors');
 const { fetchOpenTasks, permissions, whitelist, updateDataAndStatus } = require('../../middleware');
+const getRetrospectiveAssessment = require('../../helpers/retrospective-assessment');
 
 const router = Router({ mergeParams: true });
 
@@ -101,6 +103,32 @@ const loadVersions = (req, res, next) => {
       };
       next();
     });
+};
+
+const loadRetrospectiveAssessment = (req, res, next) => {
+  const { ProjectVersion } = req.models;
+  if (req.project.granted) {
+    return ProjectVersion.query()
+      .select('data')
+      .findById(req.project.granted.id)
+      .then(version => {
+        const ra = getRetrospectiveAssessment(version.data);
+        const hasRA = ra.required || ra.condition;
+        if (!hasRA) {
+          return next();
+        }
+        const endDate = req.project.status === 'revoked'
+          ? req.project.revocationDate
+          : req.project.expiryDate;
+        const raDate = moment(endDate).add(6, 'months').toISOString();
+        req.project = {
+          ...req.project,
+          raDate
+        };
+        next();
+      });
+  }
+  next();
 };
 
 router.get('/', (req, res, next) => {
@@ -209,6 +237,7 @@ const canDeleteAmendments = (req, res, next) => {
 router.get('/:projectId',
   permissions('project.read.single'),
   loadVersions,
+  loadRetrospectiveAssessment,
   (req, res, next) => {
     res.response = req.project;
     next();

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,9 +43,9 @@
       }
     },
     "@asl/constants": {
-      "version": "0.5.0",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/constants/-/@asl/constants-0.5.0.tgz",
-      "integrity": "sha1-8vWmqKliA9OFgZcKovO+nTWKTuI="
+      "version": "0.6.0",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/constants/-/@asl/constants-0.6.0.tgz",
+      "integrity": "sha1-jFi/OZuhU21e+q17N8l7keRNJbM="
     },
     "@asl/dictionary": {
       "version": "1.1.4",
@@ -53,9 +53,9 @@
       "integrity": "sha1-hBl7B2mAr7V6tyNcXtzK890V/Mg="
     },
     "@asl/schema": {
-      "version": "7.30.3",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-7.30.3.tgz",
-      "integrity": "sha1-b/EJ9TD9N1+14JeDq3XEtxR5e2U=",
+      "version": "7.30.4",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-7.30.4.tgz",
+      "integrity": "sha1-Rr97IIDUe0ddB0GN5bbcEJ5mcSM=",
       "requires": {
         "@asl/constants": "^0.3.2",
         "knex": "^0.19.5",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "npm run test:lint && npm run test:unit",
     "test:lint": "eslint .",
     "pretest:unit": "npm run migrate",
-    "test:unit": "mocha ./test/specs --require dotenv/config --recursive --exit",
+    "test:unit": "mocha ./test/specs --require dotenv/config --recursive --exit --timeout 5000",
     "migrate": "DATABASE_NAME=asl-test knex migrate:latest --knexfile ./node_modules/@asl/schema/knexfile.js",
     "rollback": "DATABASE_NAME=asl-test knex migrate:rollback"
   },
@@ -24,8 +24,8 @@
   },
   "homepage": "https://github.com/UKHomeOffice/asl-public-api#readme",
   "dependencies": {
-    "@asl/constants": "^0.5.0",
-    "@asl/schema": "^7.30.3",
+    "@asl/constants": "^0.6.0",
+    "@asl/schema": "^7.30.4",
     "@asl/service": "^7.17.0",
     "express": "^4.16.3",
     "lodash": "^4.17.15",

--- a/test/data/default.js
+++ b/test/data/default.js
@@ -333,6 +333,8 @@ module.exports = models => {
               id: 'ba3f4fdf-27e4-461e-a251-111111111111',
               title: 'Test project',
               status: 'inactive',
+              expiryDate: null,
+              revocationDate: null,
               establishmentId: 101,
               schemaVersion: 1
             },
@@ -340,6 +342,35 @@ module.exports = models => {
               id: 'ba3f4fdf-27e4-461e-a251-333333333333',
               title: 'Test legacy project',
               status: 'inactive',
+              expiryDate: null,
+              revocationDate: null,
+              establishmentId: 101,
+              schemaVersion: 0
+            },
+            {
+              id: 'ba3f4fdf-27e4-461e-a251-444444444444',
+              title: 'Non-RA project',
+              status: 'active',
+              expiryDate: '2025-01-01T12:00:00Z',
+              revocationDate: null,
+              establishmentId: 101,
+              schemaVersion: 0
+            },
+            {
+              id: 'ba3f4fdf-27e4-461e-a251-555555555555',
+              title: 'RA project',
+              status: 'active',
+              expiryDate: '2025-01-01T12:00:00Z',
+              revocationDate: null,
+              establishmentId: 101,
+              schemaVersion: 0
+            },
+            {
+              id: 'ba3f4fdf-27e4-461e-a251-666666666666',
+              title: 'Revoked RA project',
+              status: 'revoked',
+              expiryDate: '2025-01-01T12:00:00Z',
+              revocationDate: '2024-01-01T12:00:00Z',
               establishmentId: 101,
               schemaVersion: 0
             }
@@ -362,6 +393,7 @@ module.exports = models => {
           return ProjectVersion.query().insert([
             {
               projectId: 'ba3f4fdf-27e4-461e-a251-111111111111',
+              status: 'submitted',
               id: 'ba3f4fdf-27e4-461e-a251-222222222222',
               data: {
                 protocols: [
@@ -377,6 +409,7 @@ module.exports = models => {
             },
             {
               projectId: 'ba3f4fdf-27e4-461e-a251-333333333333',
+              status: 'submitted',
               id: 'ba3f4fdf-27e4-461e-a251-444444444444',
               data: {
                 protocols: [
@@ -407,6 +440,7 @@ module.exports = models => {
             },
             {
               projectId: 'ba3f4fdf-27e4-461e-a251-333333333333',
+              status: 'submitted',
               id: 'ed0687a2-1a52-4cc8-b100-588a04255c59',
               data: {
                 conditions: [
@@ -414,6 +448,30 @@ module.exports = models => {
                     key: 'custom',
                     edited: 'This is a custom condition'
                   }
+                ]
+              }
+            },
+            {
+              projectId: 'ba3f4fdf-27e4-461e-a251-444444444444',
+              status: 'granted',
+              id: 'ed0687a2-1a52-4cc8-b100-588a04255c60',
+              data: {}
+            },
+            {
+              projectId: 'ba3f4fdf-27e4-461e-a251-555555555555',
+              status: 'granted',
+              id: 'ed0687a2-1a52-4cc8-b100-588a04255c61',
+              data: {
+                retrospectiveAssessment: true
+              }
+            },
+            {
+              projectId: 'ba3f4fdf-27e4-461e-a251-666666666666',
+              status: 'granted',
+              id: 'ed0687a2-1a52-4cc8-b100-588a04255c62',
+              data: {
+                species: [
+                  'marmosets'
                 ]
               }
             }

--- a/test/specs/helpers/retrospective-assessment.js
+++ b/test/specs/helpers/retrospective-assessment.js
@@ -1,0 +1,138 @@
+const assert = require('assert');
+const helper = require('../../../lib/helpers/retrospective-assessment');
+
+describe('retrospective-assessment', () => {
+
+  describe('required', () => {
+
+    it('returns false if not passed a project', () => {
+      assert.equal(helper().required, false);
+    });
+
+    it('returns false if project does not match any criteria', () => {
+      const project = {
+        species: ['mice', 'rats'],
+        'species-other': ['Cows'],
+        'endangered-animals': false,
+        protocols: [
+          { severity: 'moderate' },
+          { severity: 'mild' }
+        ]
+      };
+      assert.equal(helper(project).required, false);
+    });
+
+    it('returns true if project uses horses', () => {
+      const project = {
+        species: ['mice', 'rats', 'horses'],
+        'endangered-animals': false,
+        protocols: [
+          { severity: 'moderate' },
+          { severity: 'mild' }
+        ]
+      };
+      assert.equal(helper(project).required, true);
+    });
+
+    it('returns true if project uses an "other" species which matches a restricted species', () => {
+      const project = {
+        species: ['mice', 'rats'],
+        'species-other': ['Rhesus macaques'],
+        'endangered-animals': false,
+        protocols: [
+          { severity: 'moderate' },
+          { severity: 'mild' }
+        ]
+      };
+      assert.equal(helper(project).required, true);
+    });
+
+    it('returns true if project uses endangered species', () => {
+      const project = {
+        species: ['mice', 'rats'],
+        'endangered-animals': true,
+        protocols: [
+          { severity: 'moderate' },
+          { severity: 'mild' }
+        ]
+      };
+      assert.equal(helper(project).required, true);
+    });
+
+    it('returns true if project has a severe protocol', () => {
+      const project = {
+        species: ['mice', 'rats'],
+        'endangered-animals': false,
+        protocols: [
+          { severity: 'moderate' },
+          { severity: 'mild' },
+          { severity: 'severe' }
+        ]
+      };
+      assert.equal(helper(project).required, true);
+    });
+
+  });
+
+  describe('condition', () => {
+
+    it('returns false if not passed a project', () => {
+      assert.equal(helper().condition, false);
+    });
+
+    it('returns true if `retrospectiveAssessment` property is true', () => {
+      const project = {
+        retrospectiveAssessment: true
+      };
+      assert.equal(helper(project).condition, true);
+    });
+
+    it('returns false if `retrospectiveAssessment` property is false', () => {
+      const project = {
+        retrospectiveAssessment: false
+      };
+      assert.equal(helper(project).condition, false);
+    });
+
+    it('returns true if `retrospectiveAssessment` is an object with child property `retrospective-assessment-required` that is true', () => {
+      const project = {
+        retrospectiveAssessment: {
+          'retrospective-assessment-required': true
+        }
+      };
+      assert.equal(helper(project).condition, true);
+    });
+
+    it('returns true if there is a `retrospective-assessment` condition', () => {
+      const project = {
+        conditions: [
+          { key: 'other-condition' },
+          { key: 'retrospective-assessment' }
+        ]
+      };
+      assert.equal(helper(project).condition, true);
+    });
+
+    it('prioritises the top-level property if it exists alongside conditions', () => {
+      const project = {
+        retrospectiveAssessment: false,
+        conditions: [
+          { key: 'other-condition' },
+          { key: 'retrospective-assessment' }
+        ]
+      };
+      assert.equal(helper(project).condition, false);
+    });
+
+    it('returns false if no matching conditions and no top-level property', () => {
+      const project = {
+        conditions: [
+          { key: 'other-condition' }
+        ]
+      };
+      assert.equal(helper(project).condition, false);
+    });
+
+  });
+
+});

--- a/test/specs/project-versions.js
+++ b/test/specs/project-versions.js
@@ -70,4 +70,46 @@ describe('/projects', () => {
       });
   });
 
+  describe('retrospective assessment', () => {
+
+    it('sets properties to false if RA is not required', () => {
+      return request(this.api)
+        .get('/establishment/101/project/ba3f4fdf-27e4-461e-a251-444444444444/project-version/ed0687a2-1a52-4cc8-b100-588a04255c60')
+        .expect(200)
+        .expect(response => {
+          assert.equal(response.body.data.retrospectiveAssessment, false);
+          assert.equal(response.body.data.retrospectiveAssessmentRequired, false);
+        });
+    });
+
+    it('includes retrospectiveAssessment property when RA applies', () => {
+      return request(this.api)
+        .get('/establishment/101/project/ba3f4fdf-27e4-461e-a251-555555555555/project-version/ed0687a2-1a52-4cc8-b100-588a04255c61')
+        .expect(200)
+        .expect(response => {
+          assert.equal(response.body.data.retrospectiveAssessment, true);
+        });
+    });
+
+    it('set retrospectiveAssessmentRequired property to false when RA was manually added', () => {
+      return request(this.api)
+        .get('/establishment/101/project/ba3f4fdf-27e4-461e-a251-555555555555/project-version/ed0687a2-1a52-4cc8-b100-588a04255c61')
+        .expect(200)
+        .expect(response => {
+          assert.equal(response.body.data.retrospectiveAssessmentRequired, false);
+        });
+    });
+
+    it('sets retrospectiveAssessmentRequired property to true when RA is a result of project data', () => {
+      return request(this.api)
+        .get('/establishment/101/project/ba3f4fdf-27e4-461e-a251-666666666666/project-version/ed0687a2-1a52-4cc8-b100-588a04255c62')
+        .expect(200)
+        .expect(response => {
+          assert.equal(response.body.data.retrospectiveAssessment, true);
+          assert.equal(response.body.data.retrospectiveAssessmentRequired, true);
+        });
+    });
+
+  });
+
 });

--- a/test/specs/projects.js
+++ b/test/specs/projects.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const request = require('supertest');
+const moment = require('moment');
 const apiHelper = require('../helpers/api');
 
 const INACTIVE_PROJECT_ID = 'bf22f7cd-cf85-42ef-93da-02b709df67be';
@@ -87,6 +88,46 @@ describe('/projects', () => {
           assert.equal(body.id, ASRU_AMENDMENT_PROJECT_ID);
         });
     });
+  });
+
+  describe('GET /:id', () => {
+
+    it('does not include RA date on draft projects', () => {
+      return request(this.api)
+        .get('/establishment/101/projects/ba3f4fdf-27e4-461e-a251-333333333333')
+        .expect(200)
+        .expect(response => {
+          assert.equal(response.body.data.raDate, undefined);
+        });
+    });
+
+    it('does not include RA date on projects without RA', () => {
+      return request(this.api)
+        .get('/establishment/101/projects/ba3f4fdf-27e4-461e-a251-444444444444')
+        .expect(200)
+        .expect(response => {
+          assert.equal(response.body.data.raDate, undefined);
+        });
+    });
+
+    it('includes RA date on granted projects with RA condition', () => {
+      return request(this.api)
+        .get('/establishment/101/projects/ba3f4fdf-27e4-461e-a251-555555555555')
+        .expect(200)
+        .expect(response => {
+          assert.equal(moment(response.body.data.raDate).format('YYYY-MM-DD'), '2025-07-01');
+        });
+    });
+
+    it('calculates RA date from revocation date on revoked projects', () => {
+      return request(this.api)
+        .get('/establishment/101/projects/ba3f4fdf-27e4-461e-a251-666666666666')
+        .expect(200)
+        .expect(response => {
+          assert.equal(moment(response.body.data.raDate).format('YYYY-MM-DD'), '2024-07-01');
+        });
+    });
+
   });
 
 });


### PR DESCRIPTION
Instead of doing the calculations of RA based on project state in the UI at render time, do the logic here and reduce the need for sending large payloads of data and js to the client.

Logic for RA has been copied directly from asl/projects. Once this is in place then it can be removed from there and make use of the API properties instead.