### PR TITLE
Move RA flags into the version data

### DIFF
--- a/lib/routers/establishment/project-versions.js
+++ b/lib/routers/establishment/project-versions.js
@@ -11,8 +11,8 @@ const router = Router({ mergeParams: true });
 const normalise = (version) => {
   // add RA flags to project version
   const ra = getRetrospectiveAssessment(version.data);
-  version.retrospectiveAssessment = ra.required || ra.condition;
-  version.retrospectiveAssessmentRequired = ra.required;
+  version.data.retrospectiveAssessment = ra.required || ra.condition;
+  version.data.retrospectiveAssessmentRequired = ra.required;
 
   if (version.project.schemaVersion !== 0) {
     return version;

--- a/test/specs/project-versions.js
+++ b/test/specs/project-versions.js
@@ -77,8 +77,8 @@ describe('/projects', () => {
         .get('/establishment/101/project/ba3f4fdf-27e4-461e-a251-444444444444/project-version/ed0687a2-1a52-4cc8-b100-588a04255c60')
         .expect(200)
         .expect(response => {
-          assert.equal(response.body.data.retrospectiveAssessment, false);
-          assert.equal(response.body.data.retrospectiveAssessmentRequired, false);
+          assert.equal(response.body.data.data.retrospectiveAssessment, false);
+          assert.equal(response.body.data.data.retrospectiveAssessmentRequired, false);
         });
     });
 
@@ -87,7 +87,7 @@ describe('/projects', () => {
         .get('/establishment/101/project/ba3f4fdf-27e4-461e-a251-555555555555/project-version/ed0687a2-1a52-4cc8-b100-588a04255c61')
         .expect(200)
         .expect(response => {
-          assert.equal(response.body.data.retrospectiveAssessment, true);
+          assert.equal(response.body.data.data.retrospectiveAssessment, true);
         });
     });
 
@@ -96,7 +96,7 @@ describe('/projects', () => {
         .get('/establishment/101/project/ba3f4fdf-27e4-461e-a251-555555555555/project-version/ed0687a2-1a52-4cc8-b100-588a04255c61')
         .expect(200)
         .expect(response => {
-          assert.equal(response.body.data.retrospectiveAssessmentRequired, false);
+          assert.equal(response.body.data.data.retrospectiveAssessmentRequired, false);
         });
     });
 
@@ -105,8 +105,8 @@ describe('/projects', () => {
         .get('/establishment/101/project/ba3f4fdf-27e4-461e-a251-666666666666/project-version/ed0687a2-1a52-4cc8-b100-588a04255c62')
         .expect(200)
         .expect(response => {
-          assert.equal(response.body.data.retrospectiveAssessment, true);
-          assert.equal(response.body.data.retrospectiveAssessmentRequired, true);
+          assert.equal(response.body.data.data.retrospectiveAssessment, true);
+          assert.equal(response.body.data.data.retrospectiveAssessmentRequired, true);
         });
     });
 


### PR DESCRIPTION
These were put in the wrong place initially. They should be in the version data so that they're accessible inside projects.

Note: this isn't being used anywhere downstream yet, so should be totally b/c