### PR TITLE
Hide nonsensical PIL billing end dates

### DIFF
--- a/lib/routers/establishment/billing.js
+++ b/lib/routers/establishment/billing.js
@@ -13,11 +13,13 @@ const populateDates = (id, start, end) => pil => {
       return (t.createdAt > date && t.createdAt < end) ? t.createdAt : date;
     }, pil.issueDate);
 
-  pil.endDate = pil.pilTransfers
-    .filter(t => t.fromEstablishmentId === id)
-    .reduce((date, t) => {
-      return ((!date || t.createdAt > date) && t.createdAt > pil.startDate) ? t.createdAt : date;
-    }, null) || pil.revocationDate;
+  if (pil.status !== 'active' || pil.establishmentId !== id) {
+    pil.endDate = pil.pilTransfers
+      .filter(t => t.fromEstablishmentId === id)
+      .reduce((date, t) => {
+        return ((!date || t.createdAt > date) && t.createdAt > pil.startDate) ? t.createdAt : date;
+      }, null) || pil.revocationDate;
+  }
 
   return pil;
 };


### PR DESCRIPTION
If a PIL is active at an establishment then don't calculate and end date for it, as it has not ended.

This is to deal with some PILs that were revoked and reactivated that show end dates before their start date as a result.