### PR TITLE
Include all related open tasks in a profile response

### DIFF
--- a/lib/middleware/fetch-open-profile-tasks.js
+++ b/lib/middleware/fetch-open-profile-tasks.js
@@ -1,0 +1,19 @@
+
+module.exports = id => (req, res, next) => {
+  if (!req.establishment || !req.profileId) {
+    return next();
+  }
+
+  return req.workflow.profileTasks(req.profileId, req.establishment.id)
+    .then(workflowResponse => {
+      res.meta = res.meta || {};
+      res.meta.openTasks = workflowResponse.json.data || [];
+      next();
+    })
+    .catch(error => {
+      req.log('error', { ...error, stack: error.stack, message: error.message });
+      res.meta = res.meta || {};
+      res.meta.openTasks = [{ action: 'failed' }];
+      next();
+    });
+};

--- a/lib/middleware/index.js
+++ b/lib/middleware/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   fetchOpenTasks: require('./fetch-open-tasks'),
+  fetchOpenProfileTasks: require('./fetch-open-profile-tasks'),
   permissions: require('./permissions'),
   whitelist: require('./whitelist'),
   validateSchema: require('./validate-schema'),

--- a/lib/routers/profile/person.js
+++ b/lib/routers/profile/person.js
@@ -1,7 +1,7 @@
 const { Router } = require('express');
 const isUUID = require('uuid-validate');
 const { get, uniq } = require('lodash');
-const { fetchOpenTasks, permissions, whitelist, validateSchema, updateDataAndStatus } = require('../../middleware');
+const { fetchOpenProfileTasks, permissions, whitelist, validateSchema, updateDataAndStatus } = require('../../middleware');
 const { NotFoundError, BadRequestError } = require('../../errors');
 
 const update = () => (req, res, next) => {
@@ -123,7 +123,7 @@ router.get('/', (req, res, next) => {
       next();
     })
     .catch(next);
-}, fetchOpenTasks());
+}, fetchOpenProfileTasks());
 
 router.put('/email',
   permissions('profile.update', req => ({ profileId: req.profileId })),


### PR DESCRIPTION
The `fetchOpenTasks()` middleware only fetches tasks that cause changes to the profile itself, and ignores changes to related models like roles etc.

This change will return any open task that has that profile as a subject or changed by (which includes roles).