### PR TITLE
Make previous years licence fees the default

### DIFF
--- a/lib/routers/establishment/billing.js
+++ b/lib/routers/establishment/billing.js
@@ -4,6 +4,14 @@ const { NotFoundError } = require('@asl/service/errors');
 const { permissions } = require('../../middleware');
 const { fees } = require('@asl/constants');
 
+const getDefaultYear = () => {
+  const lastYear = (new Date()).getFullYear() - 1;
+  if (Object.keys(fees).includes(lastYear.toString())) {
+    return lastYear;
+  }
+  return Object.keys(fees).pop();
+};
+
 const router = Router({ mergeParams: true });
 
 const populateDates = (id, start, end) => pil => {
@@ -36,7 +44,7 @@ router.use(permissions('establishment.licenceFees'));
 router.get('*', (req, res, next) => {
   let year = req.query.year;
   if (!year) {
-    year = Object.keys(fees).pop();
+    year = getDefaultYear();
     res.meta.year = year;
     res.response = {};
     return next('router');

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,9 +43,9 @@
       }
     },
     "@asl/constants": {
-      "version": "0.6.0",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/constants/-/@asl/constants-0.6.0.tgz",
-      "integrity": "sha1-jFi/OZuhU21e+q17N8l7keRNJbM="
+      "version": "0.7.0",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/constants/-/@asl/constants-0.7.0.tgz",
+      "integrity": "sha1-dNJiI2O5wYp7oRZ+LyX0mksZInc="
     },
     "@asl/dictionary": {
       "version": "1.1.4",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/UKHomeOffice/asl-public-api#readme",
   "dependencies": {
-    "@asl/constants": "^0.6.0",
+    "@asl/constants": "^0.7.0",
     "@asl/schema": "^7.35.0",
     "@asl/service": "^7.19.0",
     "express": "^4.16.3",


### PR DESCRIPTION
We have fee data for 2019/20 and 2020/21 both live now. Since we're just beyond the end of the financial year the most likely default year will be the just ended one. Make that default until January, when the soon-to-end year will be default for fees display.