### PR TITLE
Throw a 404 if requesting a profile scoped under an unaffiliated establishment

### DIFF
--- a/lib/routers/profile/person.js
+++ b/lib/routers/profile/person.js
@@ -1,6 +1,6 @@
 const { Router } = require('express');
 const isUUID = require('uuid-validate');
-const { get, uniq } = require('lodash');
+const { get, uniq, some } = require('lodash');
 const { fetchOpenProfileTasks, permissions, whitelist, validateSchema, updateDataAndStatus } = require('../../middleware');
 const { NotFoundError, BadRequestError } = require('../../errors');
 
@@ -88,6 +88,9 @@ const getSingleProfile = req => {
     })
     .then(profile => {
       if (!profile) {
+        throw new NotFoundError();
+      }
+      if (req.establishment && req.establishment.id && !some(profile.establishments, est => est.id === req.establishment.id)) {
         throw new NotFoundError();
       }
       return profile;

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,15 +53,15 @@
       "integrity": "sha1-hBl7B2mAr7V6tyNcXtzK890V/Mg="
     },
     "@asl/schema": {
-      "version": "7.35.0",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-7.35.0.tgz",
-      "integrity": "sha1-72yaYhqS5YdD8ernC/CwS1c5WXk=",
+      "version": "7.37.0",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-7.37.0.tgz",
+      "integrity": "sha1-RmJtEi/1BJqohxw4kiLrkLCKDiA=",
       "requires": {
         "@asl/constants": "^0.6.2",
         "deep-diff": "^1.0.2",
         "knex": "^0.19.5",
         "lodash": "^4.17.15",
-        "minimist": "^1.2.2",
+        "minimist": "^1.2.3",
         "moment": "^2.22.2",
         "objection": "^1.2.0",
         "pg": "^7.4.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test:lint": "eslint .",
     "pretest:unit": "npm run migrate",
     "test:unit": "mocha ./test/specs",
-    "migrate": "DATABASE_NAME=asl-test knex migrate:latest --knexfile ./node_modules/@asl/schema/knexfile.js",
+    "migrate": "DATABASE_NAME=asl-test NODE_ENV=test knex migrate:latest --knexfile ./node_modules/@asl/schema/knexfile.js",
     "rollback": "DATABASE_NAME=asl-test knex migrate:rollback"
   },
   "repository": {
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/UKHomeOffice/asl-public-api#readme",
   "dependencies": {
     "@asl/constants": "^0.7.0",
-    "@asl/schema": "^7.35.0",
+    "@asl/schema": "^7.37.0",
     "@asl/service": "^7.19.0",
     "express": "^4.16.3",
     "lodash": "^4.17.15",

--- a/test/helpers/api.js
+++ b/test/helpers/api.js
@@ -8,7 +8,7 @@ const settings = {
   database: process.env.POSTGRES_DB || 'asl-test',
   user: process.env.POSTGRES_USER || 'postgres',
   host: process.env.POSTGRES_HOST || 'localhost',
-  password: process.env.POSTGRES_PASSWORD
+  password: process.env.POSTGRES_PASSWORD || 'test-password'
 };
 
 module.exports = {

--- a/test/specs/profiles.js
+++ b/test/specs/profiles.js
@@ -252,6 +252,18 @@ describe('/profiles', () => {
         });
     });
 
+    it('throws a 404 if scoped to an unaffiliated establishment when ASRU are viewing a profile', () => {
+      this.api.setUser({ id: 'licensing' });
+
+      return request(this.api)
+        // get a profile that exists in multiple establishments at a completely different establishment
+        .get('/establishment/1000/profile/ae28fb31-d867-4371-9b4f-79019e71232f')
+        .expect(404)
+        .expect(response => {
+          assert.ok(!response.body.data, 'Response should not include data');
+        });
+    });
+
     describe('with basic permissions', () => {
 
       beforeEach(() => {


### PR DESCRIPTION
If an ASRU user requests a profile then the db query is not scoped, this means it will return even if the URL scoping is not an establishment that the user is affiliated to.