### PR TITLE
Include the updated version data in response to patch

### DIFF
--- a/lib/routers/establishment/project-versions.js
+++ b/lib/routers/establishment/project-versions.js
@@ -136,7 +136,18 @@ router.put('/:versionId/:action',
   validateAction,
   canUpdate,
   userCanUpdateVersion,
-  submit()
+  submit(),
+  (req, res, next) => {
+    const { ProjectVersion } = req.models;
+    ProjectVersion.query()
+      .eager('[project, project.licenceHolder]')
+      .findById(req.version.id)
+      .then(version => {
+        res.response = normalise(version);
+      })
+      .then(() => next())
+      .catch(e => next(e));
+  }
 );
 
 router.post('/:versionId/submit',


### PR DESCRIPTION
This allows UI clients to use the response value rather than immediately sending a second GET to load the updated data.