### PR TITLE
Include a checksum of the data in the response to a project version patch

### DIFF
--- a/lib/routers/establishment/project-versions.js
+++ b/lib/routers/establishment/project-versions.js
@@ -1,4 +1,5 @@
 const { Router } = require('express');
+const shasum = require('shasum');
 const isUUID = require('uuid-validate');
 const { permissions, fetchOpenTasks } = require('../../middleware');
 const { NotFoundError, BadRequestError } = require('../../errors');
@@ -144,6 +145,7 @@ router.put('/:versionId/:action',
       .findById(req.version.id)
       .then(version => {
         res.response = normalise(version);
+        res.meta.checksum = shasum(res.response.data);
       })
       .then(() => next())
       .catch(e => next(e));

--- a/package-lock.json
+++ b/package-lock.json
@@ -5864,6 +5864,14 @@
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
       "dev": true
     },
+    "json-stable-stringify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+      "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
+      "requires": {
+        "jsonify": "~0.0.0"
+      }
+    },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -5877,6 +5885,11 @@
       "requires": {
         "minimist": "^1.2.5"
       }
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "jsx-ast-utils": {
       "version": "2.2.3",
@@ -8385,6 +8398,24 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
       "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+    },
+    "sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "shasum": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+      "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
+      "requires": {
+        "json-stable-stringify": "~0.0.0",
+        "sha.js": "~2.4.4"
+      }
     },
     "shebang-command": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "moment": "^2.24.0",
     "objection": "^2.1.3",
     "redis": "^2.8.0",
+    "shasum": "^1.0.2",
     "uuid-validate": "0.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
This will allow clients to compare their locally resolved state to the remote state but without having to include the complete data in the response.