### PR TITLE
Make id parameter in getOpenTasks middleware immutable

### DIFF
--- a/lib/middleware/fetch-open-profile-tasks.js
+++ b/lib/middleware/fetch-open-profile-tasks.js
@@ -1,5 +1,5 @@
 
-module.exports = id => (req, res, next) => {
+module.exports = () => (req, res, next) => {
   if (!req.establishment || !req.profileId) {
     return next();
   }

--- a/lib/middleware/fetch-open-tasks.js
+++ b/lib/middleware/fetch-open-tasks.js
@@ -1,15 +1,18 @@
 const { get, isFunction } = require('lodash');
 
-module.exports = id => (req, res, next) => {
-  if (!id && !get(res, 'response.id')) {
+module.exports = getId => (req, res, next) => {
+
+  let id = get(res, 'response.id');
+
+  if (isFunction(getId)) {
+    id = getId(req, res);
+  }
+
+  if (!id) {
     return next();
   }
 
-  if (isFunction(id)) {
-    id = id(req, res);
-  }
-
-  return req.workflow.openTasks(id || res.response.id)
+  return req.workflow.openTasks(id)
     .then(workflowResponse => {
       res.meta = res.meta || {};
       res.meta.openTasks = workflowResponse.json.data || [];

--- a/test/specs/middleware/fetch-open-tasks.js
+++ b/test/specs/middleware/fetch-open-tasks.js
@@ -1,0 +1,24 @@
+const sinon = require('sinon');
+const assert = require('assert');
+const fetch = require('../../../lib/middleware/fetch-open-tasks');
+
+describe('Open tasks middleware', () => {
+
+  it('does not mutate getId parameter', () => {
+
+    const req = {
+      workflow: {
+        openTasks: sinon.stub().resolves({ json: { data: [] } })
+      }
+    };
+
+    const middleware = fetch(req => req.id);
+    middleware({ ...req, id: 1 }, {}, () => null);
+    middleware({ ...req, id: 2 }, {}, () => null);
+
+    assert.ok(req.workflow.openTasks.calledWith(1));
+    assert.ok(req.workflow.openTasks.calledWith(2));
+
+  });
+
+});


### PR DESCRIPTION
Mutating the `id` by assigning the result of a function call to it would overwrite the id parameter for subsequent calls to the same function, and so once one project version had been loaded, that same id would be used for all subsequent calls to the middleware.

Use a separate internal variable to store the id within the scope of a single request, to avoid mutating the router level parameter.