### PR TITLE
Attach PIL review metadata to PIL when part of profile

### DIFF
--- a/lib/helpers/pils.js
+++ b/lib/helpers/pils.js
@@ -1,9 +1,10 @@
 const moment = require('moment');
 
-const attachReviewDue = (months = 3) => pil => {
+const attachReviewDue = (pil, n = 3, unit = 'months') => {
+  pil.reviewDate = pil.reviewDate || moment(pil.updatedAt).add(5, 'years').toISOString();
   return {
     ...pil,
-    reviewDue: moment(pil.reviewDate).isBefore(moment().add(months, 'months')),
+    reviewDue: moment(pil.reviewDate).isBefore(moment().add(n, unit)),
     reviewOverdue: moment(pil.reviewDate).isBefore(moment())
   };
 };

--- a/lib/routers/establishment/pils.js
+++ b/lib/routers/establishment/pils.js
@@ -55,7 +55,7 @@ router.get('/',
       .then(([total, pils]) => {
         res.meta.total = total;
         res.meta.count = pils.total;
-        res.response = pils.results.map(attachReviewDue(2));
+        res.response = pils.results.map(pil => attachReviewDue(pil, 2, 'months'));
         next();
       })
       .catch(next);

--- a/lib/routers/profile/person.js
+++ b/lib/routers/profile/person.js
@@ -2,6 +2,7 @@ const { Router } = require('express');
 const isUUID = require('uuid-validate');
 const { get, some } = require('lodash');
 const { fetchOpenProfileTasks, permissions, whitelist, validateSchema, updateDataAndStatus } = require('../../middleware');
+const { attachReviewDue } = require('../../helpers/pils');
 const { NotFoundError, BadRequestError } = require('../../errors');
 const Keycloak = require('../../helpers/keycloak');
 
@@ -173,6 +174,9 @@ module.exports = (settings) => {
     Promise.resolve()
       .then(() => getSingleProfile(req))
       .then(profile => {
+        if (profile.pil) {
+          profile.pil = attachReviewDue(profile.pil, 3, 'months');
+        }
         res.response = profile;
         next();
       })

--- a/lib/routers/profile/pil.js
+++ b/lib/routers/profile/pil.js
@@ -1,6 +1,5 @@
 const { Router } = require('express');
 const { get } = require('lodash');
-const moment = require('moment');
 const { NotFoundError, BadRequestError, UnrecognisedActionError } = require('../../errors');
 const { fetchOpenTasks, permissions, validateSchema, whitelist, updateDataAndStatus } = require('../../middleware');
 const { attachReviewDue } = require('../../helpers/pils');
@@ -109,7 +108,6 @@ router.param('pilId', (req, res, next, id) => {
       if (!pil) {
         throw new NotFoundError();
       }
-      pil.reviewDate = pil.reviewDate || moment(pil.updatedAt).add(5, 'years').toISOString();
       pil.procedures = pil.procedures || [];
       pil.species = pil.species || [];
       req.pil = pil;
@@ -122,7 +120,7 @@ router.get('/:pilId',
   permissions('pil.read'),
   attachEstablishmentDetails,
   (req, res, next) => {
-    res.response = attachReviewDue(3)(req.pil);
+    res.response = attachReviewDue(req.pil, 3, 'months');
     next();
   },
   fetchOpenTasks()

--- a/test/specs/user.js
+++ b/test/specs/user.js
@@ -27,6 +27,17 @@ describe('/me', () => {
         });
     });
 
+    it('adds PIL review metadata to response', () => {
+      return request(this.api)
+        .get('/me')
+        .expect(200)
+        .expect(response => {
+          assert.equal(response.body.data.pil.reviewDate, '2025-01-01T12:00:00.000Z');
+          assert.equal(response.body.data.pil.reviewDue, false);
+          assert.equal(response.body.data.pil.reviewOverdue, false);
+        });
+    });
+
     it('includes a list of allowed actions', () => {
       const actions = {
         global: [],


### PR DESCRIPTION
Currently if requesting a specific PIL on the PIL endpoint then review data metadata is attached, but not when getting a PIL as part of a profile.

This prevents the PIL review due banners from being rendered on the dashboard as that uses the logged-in user's profile rather than making an explicit call to fetch the PIL.