### PR TITLE
Update tests and fixtures for billing

### DIFF
--- a/test/data/default.js
+++ b/test/data/default.js
@@ -99,7 +99,7 @@ module.exports = models => {
       },
       {
         id: ids.establishments.marvell,
-        issueDate: '2020-01-01T12:00:00Z',
+        issueDate: '2020-07-01T12:00:00Z',
         name: 'Marvell Pharmaceuticals',
         country: 'england',
         address: '101 High Street',
@@ -113,14 +113,14 @@ module.exports = models => {
         id: ids.establishments.revokedEstablishment1,
         name: 'Invisible Pharma 2',
         issueDate: '2017-01-01T12:00:00Z',
-        revocationDate: '2018-01-01T12:00:00Z',
+        revocationDate: '2019-01-01T12:00:00Z',
         status: 'revoked'
       },
       {
         id: ids.establishments.revokedEstablishment2,
         name: 'Invisible Pharma 3',
         issueDate: '2017-01-01T12:00:00Z',
-        revocationDate: '2020-01-01T12:00:00Z',
+        revocationDate: '2020-07-01T12:00:00Z',
         status: 'revoked'
       }
     ]))
@@ -517,7 +517,7 @@ module.exports = models => {
         pilId: ids.pils.linfordChristie,
         fromEstablishmentId: ids.establishments.marvell,
         toEstablishmentId: ids.establishments.croydon,
-        createdAt: '2019-01-01T12:00:00Z'
+        createdAt: '2020-01-01T12:00:00Z'
       }
     ]))
     .then(() => models.Invitation.query().insert([

--- a/test/specs/billing.js
+++ b/test/specs/billing.js
@@ -27,7 +27,7 @@ describe('/billing', () => {
 
   it('returns number of billable PILs for the establishment', () => {
     return request(this.api)
-      .get(`/establishment/${ids.establishments.croydon}/billing?year=2019`)
+      .get(`/establishment/${ids.establishments.croydon}/billing?year=2020`)
       .expect(200)
       .expect(response => {
         assert.equal(response.body.data.numberOfPils, 4);
@@ -36,7 +36,7 @@ describe('/billing', () => {
 
   it('includes transfered PILs in the response', () => {
     return request(this.api)
-      .get(`/establishment/${ids.establishments.marvell}/billing?year=2018`)
+      .get(`/establishment/${ids.establishments.marvell}/billing?year=2019`)
       .expect(200)
       .expect(response => {
         assert.equal(response.body.data.numberOfPils, 1);
@@ -45,18 +45,18 @@ describe('/billing', () => {
 
   it('returns pils, pel and total fees', () => {
     return request(this.api)
-      .get(`/establishment/${ids.establishments.croydon}/billing?year=2019`)
+      .get(`/establishment/${ids.establishments.croydon}/billing?year=2020`)
       .expect(200)
       .expect(response => {
-        assert.equal(response.body.data.pils, 4 * 275);
-        assert.equal(response.body.data.pel, 826);
-        assert.equal(response.body.data.total, (4 * 275) + 826);
+        assert.equal(response.body.data.pils, 4 * 299);
+        assert.equal(response.body.data.pel, 915);
+        assert.equal(response.body.data.total, (4 * 299) + 915);
       });
   });
 
   it('returns a PEL fee of zero if the establishment was inactive', () => {
     return request(this.api)
-      .get(`/establishment/${ids.establishments.marvell}/billing?year=2018`)
+      .get(`/establishment/${ids.establishments.marvell}/billing?year=2019`)
       .expect(200)
       .expect(response => {
         assert.equal(response.body.data.pel, 0);
@@ -66,7 +66,7 @@ describe('/billing', () => {
 
   it('returns a PEL fee of zero if the establishment was revoked before the billing period', () => {
     return request(this.api)
-      .get(`/establishment/${ids.establishments.revokedEstablishment1}/billing?year=2019`)
+      .get(`/establishment/${ids.establishments.revokedEstablishment1}/billing?year=2020`)
       .expect(200)
       .expect(response => {
         assert.equal(response.body.data.pel, 0);
@@ -75,19 +75,19 @@ describe('/billing', () => {
 
   it('returns a PEL fee if the establishment was revoked during the billing period', () => {
     return request(this.api)
-      .get(`/establishment/${ids.establishments.revokedEstablishment2}/billing?year=2019`)
+      .get(`/establishment/${ids.establishments.revokedEstablishment2}/billing?year=2020`)
       .expect(200)
       .expect(response => {
-        assert.equal(response.body.data.pel, 826);
+        assert.equal(response.body.data.pel, 915);
       });
   });
 
   it('returns fees for the current year in response', () => {
     return request(this.api)
-      .get(`/establishment/${ids.establishments.croydon}/billing?year=2018`)
+      .get(`/establishment/${ids.establishments.croydon}/billing?year=2019`)
       .expect(200)
       .expect(response => {
-        assert.deepEqual(response.body.data.fees, { pil: 257, pel: 757 });
+        assert.deepEqual(response.body.data.fees, { pil: 275, pel: 826 });
       });
   });
 
@@ -95,7 +95,7 @@ describe('/billing', () => {
 
     it('returns list of billable PILs for the establishment', () => {
       return request(this.api)
-        .get(`/establishment/${ids.establishments.croydon}/billing/pils?year=2019`)
+        .get(`/establishment/${ids.establishments.croydon}/billing/pils?year=2020`)
         .expect(200)
         .expect(response => {
           assert.equal(response.body.data.length, 4);
@@ -104,7 +104,7 @@ describe('/billing', () => {
 
     it('removes `pilTransfers` property from PIL response', () => {
       return request(this.api)
-        .get(`/establishment/${ids.establishments.croydon}/billing/pils?year=2019`)
+        .get(`/establishment/${ids.establishments.croydon}/billing/pils?year=2020`)
         .expect(200)
         .expect(response => {
           response.body.data.forEach(pil => {
@@ -115,7 +115,7 @@ describe('/billing', () => {
 
     it('only returns current establishment on profile where user has multiple establishments', () => {
       return request(this.api)
-        .get(`/establishment/${ids.establishments.croydon}/billing/pils?year=2019`)
+        .get(`/establishment/${ids.establishments.croydon}/billing/pils?year=2020`)
         .expect(200)
         .expect(response => {
           const pil = response.body.data.find(p => p.id === ids.pils.multipleEstablishments);
@@ -126,7 +126,7 @@ describe('/billing', () => {
 
     it('does not return establishments on profile is user is no longer affiliated to scoped establishment', () => {
       return request(this.api)
-        .get(`/establishment/${ids.establishments.marvell}/billing/pils?year=2018`)
+        .get(`/establishment/${ids.establishments.marvell}/billing/pils?year=2019`)
         .expect(200)
         .expect(response => {
           const pil = response.body.data.find(p => p.id === ids.pils.linfordChristie);
@@ -136,7 +136,7 @@ describe('/billing', () => {
 
     it('sets establishment id on PIL to scoped establishment even if they no longer hold it', () => {
       return request(this.api)
-        .get(`/establishment/${ids.establishments.marvell}/billing/pils?year=2018`)
+        .get(`/establishment/${ids.establishments.marvell}/billing/pils?year=2019`)
         .expect(200)
         .expect(response => {
           response.body.data.forEach(pil => {
@@ -147,29 +147,29 @@ describe('/billing', () => {
 
     it('sets start date on returned PILs', () => {
       return request(this.api)
-        .get(`/establishment/${ids.establishments.croydon}/billing/pils?year=2019`)
+        .get(`/establishment/${ids.establishments.croydon}/billing/pils?year=2020`)
         .expect(200)
         .expect(response => {
           const transfered = response.body.data.find(pil => pil.id === ids.pils.linfordChristie);
           const notTransfered = response.body.data.find(pil => pil.id === ids.pils.multipleEstablishments);
-          assert.equal(transfered.startDate, '2019-01-01T12:00:00.000Z'); // start date is transfer date
+          assert.equal(transfered.startDate, '2020-01-01T12:00:00.000Z'); // start date is transfer date
           assert.equal(notTransfered.startDate, '2016-01-01T12:00:00.000Z'); // start date is issue date
         });
     });
 
     it('sets end date on returned PILs', () => {
       return request(this.api)
-        .get(`/establishment/${ids.establishments.marvell}/billing/pils?year=2018`)
+        .get(`/establishment/${ids.establishments.marvell}/billing/pils?year=2019`)
         .expect(200)
         .expect(response => {
           const transfered = response.body.data.find(pil => pil.id === ids.pils.linfordChristie);
-          assert.equal(transfered.endDate, '2019-01-01T12:00:00.000Z'); // end date is transfer date
+          assert.equal(transfered.endDate, '2020-01-01T12:00:00.000Z'); // end date is transfer date
         });
     });
 
     it('does not set end date on active PILs with a revocation date', () => {
       return request(this.api)
-        .get(`/establishment/${ids.establishments.croydon}/billing/pils?year=2018`)
+        .get(`/establishment/${ids.establishments.croydon}/billing/pils?year=2019`)
         .expect(200)
         .expect(response => {
           const active = response.body.data.find(pil => pil.id === ids.pils.multipleEstablishments);
@@ -179,7 +179,7 @@ describe('/billing', () => {
 
     it('can filter the results by profile name', () => {
       return request(this.api)
-        .get(`/establishment/${ids.establishments.croydon}/billing/pils?year=2019&filter=christie`)
+        .get(`/establishment/${ids.establishments.croydon}/billing/pils?year=2020&filter=christie`)
         .expect(200)
         .expect(response => {
           const pils = response.body.data;
@@ -190,7 +190,7 @@ describe('/billing', () => {
 
     it('can filter the results by pil number', () => {
       return request(this.api)
-        .get(`/establishment/${ids.establishments.croydon}/billing/pils?year=2019&filter=c-987`)
+        .get(`/establishment/${ids.establishments.croydon}/billing/pils?year=2020&filter=c-987`)
         .expect(200)
         .expect(response => {
           const pils = response.body.data;


### PR DESCRIPTION
Billing data for 2018/19 has been removed from the API, so the tests need updating to not request 2018 data.

Push all the relevant dates forward by 1 year.