### PR TITLE
Apply permissions checks on tasks

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -31,6 +31,12 @@ module.exports = settings => {
   app.use('/task(s)?', require('./routers/task'));
 
   app.use((req, res, next) => {
+    if (!req.permissionChecked) {
+      const nopes = ['/tasks'];
+      if (!nopes.includes(req.path)) {
+        req.log('info', { url: req.originalUrl, event: 'unchecked-permissions' });
+      }
+    }
     if (res.response) {
       const response = {};
       if (!req.query.onlymeta) {

--- a/lib/middleware/user.js
+++ b/lib/middleware/user.js
@@ -26,6 +26,12 @@ router.use((req, res, next) => {
     return req.workflow.create(params);
   };
 
+  const can = req.user.can;
+  req.user.can = (...args) => {
+    Object.defineProperty(req, 'permissionChecked', { value: true });
+    return can(...args);
+  };
+
   Promise.resolve()
     .then(() => getProfile())
     .then(profile => {

--- a/lib/routers/task/index.js
+++ b/lib/routers/task/index.js
@@ -52,7 +52,7 @@ router.use('/:taskId', (req, res, next) => {
   } else {
     perm = `${model}.read`;
   }
-  console.log(`Checking permissions for ${perm}`)
+
   req.user.can(perm, { id, establishment })
     .then(allowed => {
       if (allowed) {

--- a/lib/routers/task/index.js
+++ b/lib/routers/task/index.js
@@ -39,12 +39,6 @@ router.use('/:taskId', (req, res, next) => {
     id: req.task.data.id,
     establishment: req.task.data.establishmentId
   };
-  if (model === 'profile') {
-    if (id === req.user.profile.id || req.user.profile.asruUser) {
-      return next();
-    }
-    throw new UnauthorisedError();
-  }
 
   if (model === 'project') {
     const versionId = get(req.task, 'data.data.version');
@@ -57,6 +51,8 @@ router.use('/:taskId', (req, res, next) => {
     }
   } else if (model === 'role') {
     perm = 'establishment.read';
+  } else if (model === 'profile') {
+    perm = 'profile.global';
   } else {
     perm = `${model}.read`;
   }


### PR DESCRIPTION
Only expose task endpoints to people who have permission to access the underlying data object.