### PR TITLE
Sort role filters when retrieving people list

### DIFF
--- a/lib/routers/profile/index.js
+++ b/lib/routers/profile/index.js
@@ -41,7 +41,7 @@ module.exports = (settings) => {
     Promise.resolve()
       .then(() => getAllProfiles(req))
       .then(({ filters, total, profiles }) => {
-        res.meta.filters = filters;
+        res.meta.filters = filters.sort();
         res.meta.total = total;
         res.meta.count = profiles.total;
         res.response = profiles.results;


### PR DESCRIPTION
This ensures that the filters are always consistently ordered when rendered on the client.