### PR TITLE
Don't restrict what can be passed as task metadata

### DIFF
--- a/lib/routers/task/index.js
+++ b/lib/routers/task/index.js
@@ -75,7 +75,7 @@ router.get('/:taskId', (req, res, next) => {
 router.put('/:taskId/status', (req, res, next) => {
   return req.workflow.task(req.taskId).status({
     status: req.body.status,
-    meta: pick(req.body.meta, 'comment', 'restrictions', 'awerb', 'awerb-review-date', 'awerb-no-review-reason')
+    meta: req.body.meta
   })
     .then(response => {
       res.response = response.json.data;

--- a/lib/routers/task/index.js
+++ b/lib/routers/task/index.js
@@ -1,5 +1,5 @@
 const { Router } = require('express');
-const { get, pick } = require('lodash');
+const { get } = require('lodash');
 const isUUID = require('uuid-validate');
 const { NotFoundError, UnauthorisedError } = require('../../errors');
 const router = Router({ mergeParams: true });


### PR DESCRIPTION
Rather than adding yet another allowed value, just pass everything and let workflow sort it out.