### PR TITLE
Add special handling for "all named people" filter

### DIFF
--- a/lib/routers/profile/index.js
+++ b/lib/routers/profile/index.js
@@ -20,7 +20,8 @@ const getAllProfiles = req => {
     limit,
     offset,
     sort,
-    filters
+    filters,
+    includeSelf: !namedPeopleOnly
   });
 
   return Promise.resolve()

--- a/lib/routers/profile/index.js
+++ b/lib/routers/profile/index.js
@@ -6,6 +6,12 @@ const personRouter = require('./person');
 const getAllProfiles = req => {
   const { Profile } = req.models;
   const { search, sort, filters, limit, offset } = req.query;
+  let namedPeopleOnly = false;
+
+  if (filters && filters.roles && filters.roles.includes('named')) {
+    filters.roles = [];
+    namedPeopleOnly = true;
+  }
 
   const profiles = Profile.scopeToParams({
     establishmentId: (req.establishment && req.establishment.id) || undefined,
@@ -20,7 +26,7 @@ const getAllProfiles = req => {
   return Promise.resolve()
     .then(() => req.user.can('profile.read.all', req.params))
     .then(allowed => {
-      if (allowed) {
+      if (allowed && !namedPeopleOnly) {
         return profiles.getAll();
       }
       return Promise.resolve()

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,9 +54,9 @@
       "integrity": "sha1-zAfMVkySkCf0sdfp7o0vVEv5KLs="
     },
     "@asl/schema": {
-      "version": "9.0.0",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-9.0.0.tgz",
-      "integrity": "sha1-UdcaRZ8CFe7QOR1Gc5L9gbno1UI=",
+      "version": "9.2.0",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-9.2.0.tgz",
+      "integrity": "sha1-7YtwCL0ejSMlt3She9ImEEtEJb0=",
       "requires": {
         "@asl/constants": "^0.7.1",
         "csv-stringify": "^5.4.3",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/UKHomeOffice/asl-public-api#readme",
   "dependencies": {
     "@asl/constants": "^0.8.2",
-    "@asl/schema": "^9.0.0",
+    "@asl/schema": "^9.2.0",
     "@asl/service": "^8.4.1",
     "express": "^4.16.3",
     "lodash": "^4.17.19",


### PR DESCRIPTION
~Needs https://github.com/UKHomeOffice/asl-schema/pull/385~

"All named people" isn't a proper role filter but it helps to treat it like one for the UI. We can re-use the existing named people query and just clear the filter to prevent it interfering.