### PR TITLE
Remove check for PIL licence number

### DIFF
--- a/lib/routers/profile/person.js
+++ b/lib/routers/profile/person.js
@@ -189,11 +189,11 @@ function getStatus(pils) {
 }
 
 const getPil = (req, res, next) => {
-  const { pil, trainingPils, pilLicenceNumber } = req.profile;
+  const { pil, trainingPils } = req.profile;
 
   const activeTrainingPils = trainingPils.filter(p => p.status === 'active');
 
-  if (!pilLicenceNumber && !pil && !activeTrainingPils.length) {
+  if (!pil && !activeTrainingPils.length) {
     req.pil = null;
     return next();
   }


### PR DESCRIPTION
Some profiles ended up with being assigned a licence number but no PIL due to a bug in the resolver. This means that the condition that assumes they have a PIL if they have a licence number does not hold for all profiles.

Remove the assumption that if a user has a licence number then they must have a PIL because it causes errors for those users.