### PR TITLE
Don't allow editing old project versions

### DIFF
--- a/lib/routers/establishment/project-versions.js
+++ b/lib/routers/establishment/project-versions.js
@@ -93,6 +93,9 @@ router.param('versionId', (req, res, next, versionId) => {
 });
 
 const canUpdate = (req, res, next) => {
+  if (req.version.id !== req.version.project.draft) {
+    return next(new BadRequestError());
+  }
   if (req.version.status !== 'draft') {
     return next(new BadRequestError());
   }


### PR DESCRIPTION
If a version is not the most recent then reject attempts to edit it.