### PR TITLE
Add endpoints to handle email verification

### DIFF
--- a/lib/routers/user.js
+++ b/lib/routers/user.js
@@ -36,6 +36,41 @@ module.exports = (settings) => {
       .catch(next);
   });
 
+  router.post('/resend-email', (req, res, next) => {
+    const params = {
+      model: 'profile',
+      action: 'resend-email',
+      id: req.user.profile.id
+    };
+    return req.workflow.update(params)
+      .then(response => {
+        res.response = response;
+      })
+      .then(() => next())
+      .catch(next);
+  });
+
+  router.post('/confirm-email', (req, res, next) => {
+    if (req.user.profile.emailConfirmed) {
+      res.response = {};
+      return next();
+    }
+    const params = {
+      model: 'profile',
+      action: 'confirm-email',
+      id: req.user.profile.id,
+      data: {
+        token: req.body.token
+      }
+    };
+    return req.workflow.update(params)
+      .then(response => {
+        res.response = response;
+      })
+      .then(() => next())
+      .catch(next);
+  });
+
   router.use(personRouter(settings));
 
   router.use((req, res, next) => {

--- a/lib/routers/user.js
+++ b/lib/routers/user.js
@@ -1,6 +1,7 @@
 const { Router } = require('express');
-const { fetchOpenTasks } = require('../middleware');
 const moment = require('moment');
+const { pick } = require('lodash');
+const { fetchOpenTasks } = require('../middleware');
 const { UnauthorisedError } = require('../errors');
 const personRouter = require('./profile/person');
 
@@ -59,9 +60,7 @@ module.exports = (settings) => {
       model: 'profile',
       action: 'confirm-email',
       id: req.user.profile.id,
-      data: {
-        token: req.body.token
-      }
+      data: {}
     };
     return req.workflow.update(params)
       .then(response => {
@@ -69,6 +68,14 @@ module.exports = (settings) => {
       })
       .then(() => next())
       .catch(next);
+  });
+
+  router.get('/', (req, res, next) => {
+    if (!req.user.profile.emailConfirmed) {
+      res.response = pick(req.user.profile, 'firstName', 'lastName', 'email');
+      return next('router');
+    }
+    next();
   });
 
   router.use(personRouter(settings));

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,9 +54,9 @@
       "integrity": "sha1-zAfMVkySkCf0sdfp7o0vVEv5KLs="
     },
     "@asl/schema": {
-      "version": "9.7.1",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-9.7.1.tgz",
-      "integrity": "sha1-P/1vQNGklnwft7Aia4qhwqEVBt8=",
+      "version": "9.7.2",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-9.7.2.tgz",
+      "integrity": "sha1-Cgzr2NoHLbXkJNonTrinEeSJBq4=",
       "requires": {
         "@asl/constants": "^0.7.1",
         "csv-stringify": "^5.4.3",
@@ -97,9 +97,9 @@
           }
         },
         "@sinonjs/samsam": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.2.0.tgz",
-          "integrity": "sha512-CaIcyX5cDsjcW/ab7HposFWzV1kC++4HNsfnEdFJa7cP1QIuILAKV+BgfeqRXhcnSAc76r/Rh/O5C+300BwUIw==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.3.0.tgz",
+          "integrity": "sha512-hXpcfx3aq+ETVBwPlRFICld5EnrkexXuXDwqUNhDdr5L8VjvMeSRwyOa0qL7XFmR+jVWR4rUZtnxlG7RX72sBg==",
           "requires": {
             "@sinonjs/commons": "^1.6.0",
             "lodash.get": "^4.4.2",
@@ -2894,9 +2894,9 @@
       "dev": true
     },
     "csv-stringify": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.5.1.tgz",
-      "integrity": "sha512-HM0/86Ks8OwFbaYLd495tqTs1NhscZL52dC4ieKYumy8+nawQYC0xZ63w1NqLf0M148T2YLYqowoImc1giPn0g=="
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.5.3.tgz",
+      "integrity": "sha512-JKG8vIHpWPzdilp2SAmvjmAiIhD+XGKGdhZBGi8QIECgJAsFr7k5CmJIW2QkSxBBsctvmojM25s+UINzQ5NLTg=="
     },
     "cyclist": {
       "version": "1.0.1",
@@ -6997,9 +6997,9 @@
       "integrity": "sha512-bhlV7Eq09JrRIvo1eKngpwuqKtJnNhZdpdOlvrPrA4dxqXPjxSrbNrfnIDmTpwMyRszrcV4kU5ZA4mMsQUrjdg=="
     },
     "pg-cursor": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.5.0.tgz",
-      "integrity": "sha512-yypNCS1tm/aT/1/Wkd+nn3QgNgIia8/WPuf96pLwJiS8uEh+xOuaXVWsojdPqKxI5AWwX+iA1D2Pvq2X0RBjfA=="
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.5.1.tgz",
+      "integrity": "sha512-84ku3o+Nkg3vh3fLqW5wLPSGUXNZJl42Yd733EqXUpMe9HVzOTWmEury0l18kYadmB9f9ZnEMRcd8Dv/HhoYaw=="
     },
     "pg-int8": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/UKHomeOffice/asl-public-api#readme",
   "dependencies": {
     "@asl/constants": "^0.8.2",
-    "@asl/schema": "^9.7.1",
+    "@asl/schema": "^9.7.2",
     "@asl/service": "^8.4.1",
     "express": "^4.16.3",
     "http-proxy": "^1.18.1",

--- a/test/data/default.js
+++ b/test/data/default.js
@@ -16,7 +16,8 @@ module.exports = models => {
         postcode: 'A1 1AA',
         email: 'test1@example.com',
         telephone: '01234567890',
-        pilLicenceNumber: 'AB-123'
+        pilLicenceNumber: 'AB-123',
+        emailConfirmed: true
       },
       {
         id: ids.profiles.noddyHolder,
@@ -28,7 +29,8 @@ module.exports = models => {
         postcode: 'A1 1AA',
         email: 'test2@example.com',
         telephone: '01234567890',
-        pilLicenceNumber: 'D-456'
+        pilLicenceNumber: 'D-456',
+        emailConfirmed: true
       },
       {
         id: ids.profiles.cliveNacwo,
@@ -40,7 +42,8 @@ module.exports = models => {
         postcode: 'A1 1AA',
         email: 'test3@example.com',
         telephone: '01234567890',
-        pilLicenceNumber: 'F-789'
+        pilLicenceNumber: 'F-789',
+        emailConfirmed: true
       },
       {
         id: ids.profiles.noddyNacwo,
@@ -50,7 +53,8 @@ module.exports = models => {
         address: '1 Some Road',
         postcode: 'A1 1AA',
         email: 'test4@example.com',
-        telephone: '01234567890'
+        telephone: '01234567890',
+        emailConfirmed: true
       },
       {
         id: ids.profiles.multipleEstablishments,
@@ -62,7 +66,8 @@ module.exports = models => {
         postcode: 'A1 1AA',
         email: 'test5@example.com',
         telephone: '01234567890',
-        pilLicenceNumber: 'C-987'
+        pilLicenceNumber: 'C-987',
+        emailConfirmed: true
       },
       {
         id: ids.profiles.vincentMalloy,
@@ -72,14 +77,16 @@ module.exports = models => {
         address: '1 Some Road',
         postcode: 'A1 1AA',
         email: 'vincent@malloy.com',
-        telephone: '01234567890'
+        telephone: '01234567890',
+        emailConfirmed: true
       },
       {
         id: ids.profiles.hasNoPil,
         title: 'Mr',
         firstName: 'Hasnø',
         lastName: 'PIL',
-        email: 'hasnopil@example.com'
+        email: 'hasnopil@example.com',
+        emailConfirmed: true
       },
       {
         id: ids.profiles.marvellAdmin,
@@ -87,7 +94,17 @@ module.exports = models => {
         title: 'Mr',
         firstName: 'Ben',
         lastName: 'Marvell',
-        email: 'ibuiltmyownhouse@anditfelldown.com'
+        email: 'ibuiltmyownhouse@anditfelldown.com',
+        emailConfirmed: true
+      },
+      {
+        id: ids.profiles.unverified,
+        userId: 'unverified',
+        title: 'Mr',
+        firstName: 'Edward',
+        lastName: 'Meat',
+        email: 'unknown@example.com',
+        emailConfirmed: false
       }
     ]))
     .then(() => models.Profile.query().insert([

--- a/test/data/ids.js
+++ b/test/data/ids.js
@@ -18,7 +18,8 @@ module.exports = {
     vincentMalloy: uuid(),
     hasNoPil: uuid(),
     licensing: uuid(),
-    marvellAdmin: uuid()
+    marvellAdmin: uuid(),
+    unverified: uuid()
   },
   roles: {
     nacwoClive: uuid(),

--- a/test/helpers/with-user.js
+++ b/test/helpers/with-user.js
@@ -7,7 +7,8 @@ const makeDummyUser = user => (req, res, next) => {
     is: role => user.roles.includes(role),
     get: key => user[key],
     can: () => Promise.resolve({ json: {} }),
-    allowedActions: () => Promise.resolve({})
+    allowedActions: () => Promise.resolve({}),
+    _auth: {}
   }, user);
   next();
 };

--- a/test/specs/user.js
+++ b/test/specs/user.js
@@ -67,6 +67,20 @@ describe('/me', () => {
         });
     });
 
+    describe('unverified user', () => {
+
+      it('returns only basic data for users without verified email addresses', () => {
+        this.api.setUser({ id: 'unverified' });
+        return request(this.api)
+          .get('/me')
+          .expect(200)
+          .expect(response => {
+            assert.deepEqual(Object.keys(response.body.data), ['firstName', 'lastName', 'email'], 'only name and email fields should exist on the response data');
+          });
+      });
+
+    });
+
   });
 
   it('posts to workflow on PUT', () => {


### PR DESCRIPTION
* When creating a new user, use the email verified property from keycloak to initialise the profile to avoid having to re-verify users
* Add endpoints to pass a token to verify an email address and resend a verification email