### PR TITLE
Strip all carriage returns from json responses

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -23,6 +23,14 @@ module.exports = settings => {
     next();
   });
 
+  // tell res.json() to strip any carriage returns from the response data
+  app.set('json replacer', (key, value) => {
+    if (typeof value === 'string') {
+      return value.replace(/\r/g, '');
+    }
+    return value;
+  });
+
   app.use(require('./middleware/user'));
   app.use(require('./middleware/permissions-bypass'));
 


### PR DESCRIPTION
Sometimes users paste text with control characters into the text editors. This doesn't show up until they download the PDF. This will remove any control characters from the data.