### PR TITLE
Remove asruRops role if not asruUser

### DIFF
--- a/lib/routers/profile/person.js
+++ b/lib/routers/profile/person.js
@@ -170,6 +170,7 @@ const getSingleProfile = req => {
         delete profile.asruInspector;
         delete profile.asruAdmin;
         delete profile.asruSupport;
+        delete profile.asruRops;
       }
       return profile;
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,9 +44,9 @@
       "integrity": "sha1-zAfMVkySkCf0sdfp7o0vVEv5KLs="
     },
     "@asl/schema": {
-      "version": "9.11.1",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-9.11.1.tgz",
-      "integrity": "sha1-RDFpbanxJUnCP5eaKjPkCKF+GwY=",
+      "version": "9.11.2",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-9.11.2.tgz",
+      "integrity": "sha1-y3z+lbYn8RVLWwOj/8FS5BqgK58=",
       "requires": {
         "@asl/constants": "^0.7.1",
         "csv-stringify": "^5.4.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,9 +44,9 @@
       "integrity": "sha1-zAfMVkySkCf0sdfp7o0vVEv5KLs="
     },
     "@asl/schema": {
-      "version": "9.11.2",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-9.11.2.tgz",
-      "integrity": "sha1-y3z+lbYn8RVLWwOj/8FS5BqgK58=",
+      "version": "9.11.3",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-9.11.3.tgz",
+      "integrity": "sha1-tZoAeWvItXG4WgsnsdA+SIiXJuc=",
       "requires": {
         "@asl/constants": "^0.7.1",
         "csv-stringify": "^5.4.3",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/UKHomeOffice/asl-public-api#readme",
   "dependencies": {
     "@asl/constants": "^0.9.0",
-    "@asl/schema": "^9.11.1",
+    "@asl/schema": "^9.11.2",
     "@asl/service": "^8.4.1",
     "express": "^4.16.3",
     "http-proxy": "^1.18.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/UKHomeOffice/asl-public-api#readme",
   "dependencies": {
     "@asl/constants": "^0.9.0",
-    "@asl/schema": "^9.11.2",
+    "@asl/schema": "^9.11.3",
     "@asl/service": "^8.4.1",
     "express": "^4.16.3",
     "http-proxy": "^1.18.1",


### PR DESCRIPTION
This is possibly redundant considering the same thing being applied in schema and workflow, but as we do it for the other asru flags we might as well be consistent.

Belt n braces.