### PR TITLE
Use `get` to get property access

### DIFF
--- a/lib/routers/establishment/project-versions.js
+++ b/lib/routers/establishment/project-versions.js
@@ -102,7 +102,7 @@ router.param('versionId', (req, res, next, versionId) => {
 });
 
 const canUpdate = (req, res, next) => {
-  if (req.version.id !== req.version.project.draft.id) {
+  if (req.version.id !== get(req.version, 'project.draft.id')) {
     return next(new BadRequestError());
   }
   if (req.version.status !== 'draft') {


### PR DESCRIPTION
If the draft doesn't exist then this line throws a 500 instead of the 400 that it should.

Use `get` to prevent that.