### PR TITLE
Check role exists on DELETE

### DIFF
--- a/test/specs/roles.js
+++ b/test/specs/roles.js
@@ -27,4 +27,17 @@ describe('/roles', () => {
       });
   });
 
+  describe('delete', () => {
+
+    it('returns a 404 if the role does not exist', () => {
+      return request(this.api)
+        .delete(`/establishment/${ids.establishments.marvell}/roles/${ids.roles.nacwoClive}?type=nacwo`)
+        .expect(404)
+        .expect(() => {
+          assert.equal(this.workflow.handler.called, false);
+        });
+    });
+
+  });
+
 });


### PR DESCRIPTION
Instead of only loading the role from the database on GET, do so on all methods so that if a non-GET method is called on a role that doesn't exist then it 404s.

Context: a bug in the UI was causing incorrectly formed role deletion tasks to be created.