### PR TITLE
Don't throw a 404 if the email preferences are null

### DIFF
--- a/lib/routers/profile/email-preferences.js
+++ b/lib/routers/profile/email-preferences.js
@@ -30,7 +30,7 @@ module.exports = () => {
     return Promise.resolve()
       .then(() => req.models.EmailPreferences.query().findOne({ profileId: req.profileId }))
       .then(emailPreferences => {
-        res.response = emailPreferences;
+        res.response = emailPreferences || {};
       })
       .then(() => next())
       .catch(next);

--- a/test/specs/user.js
+++ b/test/specs/user.js
@@ -114,4 +114,15 @@ describe('/me', () => {
       .send({ data })
       .expect(400);
   });
+
+  describe('email preferences', () => {
+
+    it('does not throw a 404 if no preferences are defined', () => {
+      return request(this.api)
+        .get('/me/email-preferences')
+        .expect(200);
+    });
+
+  });
+
 });


### PR DESCRIPTION
If the email preferences are not set for a user then the response is null and so the API responds with a 404.

Return an empty object instead.