### PR TITLE
Bugfix - dont transfer to self

### DIFF
--- a/lib/routers/establishment/project-versions.js
+++ b/lib/routers/establishment/project-versions.js
@@ -13,6 +13,11 @@ const normalise = (version) => {
   version.data = version.data || {};
   version.data.protocols = version.data.protocols || [];
 
+  if (version.data.transferToEstablishment && version.data.transferToEstablishment === version.project.establishmentId) {
+    delete version.data.transferToEstablishment;
+    delete version.data.transferToEstablishmentName;
+  }
+
   if (version.project.schemaVersion !== 0) {
     return version;
   }

--- a/test/data/default.js
+++ b/test/data/default.js
@@ -369,6 +369,17 @@ module.exports = models => {
         expiryDate: '2040-01-01T12:00:00Z',
         licenceNumber: 'abc000',
         licenceHolderId: ids.profiles.activeAA
+      },
+      {
+        id: ids.projects.croydon.notATransfer,
+        establishmentId: ids.establishments.croydon,
+        title: 'Not a transfer',
+        status: 'active',
+        schemaVersion: 1,
+        issueDate: '2020-02-10T12:00:00Z',
+        expiryDate: '2040-01-01T12:00:00Z',
+        licenceNumber: 'abc000',
+        licenceHolderId: ids.profiles.linfordChristie
       }
     ]))
     .then(() => models.Project.query().insert([
@@ -527,6 +538,15 @@ module.exports = models => {
         id: uuid(),
         projectId: ids.projects.croydon.draftProjectWithMarvellAvailability,
         status: 'draft'
+      },
+      {
+        id: ids.versions.notATransfer,
+        projectId: ids.projects.croydon.notATransfer,
+        status: 'draft',
+        data: {
+          transferToEstablishment: ids.establishments.croydon,
+          transferToEstablishmentName: 'University of Croydon'
+        }
       }
     ]))
     .then(() => models.ProjectVersion.query().insert([

--- a/test/data/ids.js
+++ b/test/data/ids.js
@@ -58,7 +58,8 @@ module.exports = {
       raSevere: uuid(),
       raMultiple: uuid(),
       raAsru: uuid(),
-      raPreviousVersion: uuid()
+      raPreviousVersion: uuid(),
+      notATransfer: uuid()
     },
     marvell: {
       marvellProject: uuid(),
@@ -83,7 +84,8 @@ module.exports = {
     testLegacyProject2: uuid(),
     nonRaProject: uuid(),
     raProject: uuid(),
-    revokedRaProject: uuid()
+    revokedRaProject: uuid(),
+    notATransfer: uuid()
   },
   invitations: {
     basic: uuid(),

--- a/test/specs/project-versions.js
+++ b/test/specs/project-versions.js
@@ -25,6 +25,16 @@ describe('/projects', () => {
       });
   });
 
+  it('removes transfer fields if not a transfer (regression)', () => {
+    return request(this.api)
+      .get(`/establishment/${ids.establishments.croydon}/project/${ids.projects.croydon.notATransfer}/project-version/${ids.versions.notATransfer}`)
+      .expect(200)
+      .expect(response => {
+        assert.equal(response.body.data.data.transferToEstablishment, undefined);
+        assert.equal(response.body.data.data.transferToEstablishmentName, undefined);
+      });
+  });
+
   it('maps cameCase species fields to hyphen-separated - bugfix', () => {
     return request(this.api)
       .get(`/establishment/${ids.establishments.marvell}/project/${ids.projects.marvell.testLegacyProject}/project-version/${ids.versions.testLegacyProject}`)


### PR DESCRIPTION
If transfer field is interacted with, and then set to primary est (no transfer) then we should clean these values from data to ensure changed labels are not shown and UI functionality is as if no transfer is occuring (it is not)