### PR TITLE
Fix billing for users with multiple training PILs

### DIFF
--- a/lib/routers/establishment/billing.js
+++ b/lib/routers/establishment/billing.js
@@ -18,7 +18,7 @@ const populateDates = (establishmentId, start, end) => profile => {
   const pil = profile.pil;
 
   if (!pil) {
-    const trainingPil = profile.trainingPils.find(p => p.trainingCourse.establishmentId === establishmentId);
+    const trainingPil = profile.trainingPils.find(p => p.trainingCourse && p.trainingCourse.establishmentId === establishmentId);
     return {
       profile,
       licenceNumber: profile.pilLicenceNumber,


### PR DESCRIPTION
If a user has held two training PILs within the same year at different establishments then when querying the list of billable PILs is it possible that there are training PIL records returned with the profile where the course was at a different establishment, and so the training course details are not attached to the record.

Check that the training course record is available before reading the establishment id.