### PR TITLE
Use ROPs permissions for ROPs

### DIFF
--- a/lib/routers/establishment/procedures.js
+++ b/lib/routers/establishment/procedures.js
@@ -89,27 +89,27 @@ function canUpdate(req, res, next) {
 }
 
 app.post('/',
-  permissions('project.update'),
+  permissions('project.rops.update'),
   canUpdate,
   whitelist(req => req.models.Procedure.editableFields),
   validateModel,
   submit('create')
 );
 
-app.get('/:procedureId', permissions('project.update'), (req, res, next) => {
+app.get('/:procedureId', permissions('project.rops.update'), (req, res, next) => {
   res.response = req.procedure;
   next();
 });
 
 app.put('/:procedureId',
-  permissions('project.update'),
+  permissions('project.rops.update'),
   canUpdate,
   whitelist(req => req.models.Procedure.editableFields),
   submit('update')
 );
 
 app.delete('/:procedureId',
-  permissions('project.update'),
+  permissions('project.rops.update'),
   canUpdate,
   submit('delete')
 );


### PR DESCRIPTION
This was previously tied to project update permissions rather than rops update permissions, which are a little more expansive.