### PR TITLE
Update ROP permission that was missed in earlier commit

### DIFF
--- a/lib/routers/establishment/procedures.js
+++ b/lib/routers/establishment/procedures.js
@@ -46,7 +46,7 @@ app.param('procedureId', (req, res, next, procedureId) => {
     .catch(next);
 });
 
-app.get('/', permissions('project.update'), (req, res, next) => {
+app.get('/', permissions('project.rops.update'), (req, res, next) => {
   const { Procedure } = req.models;
   const { sort, limit, offset } = req.query;
   const ropId = req.rop.id;


### PR DESCRIPTION
Used specific ROP level permissions to manage ROP access.