### PR TITLE
Don't attach review metadata to inactive PILs

### DIFF
--- a/lib/helpers/pils.js
+++ b/lib/helpers/pils.js
@@ -1,6 +1,9 @@
 const moment = require('moment');
 
 const attachReviewDue = (pil, n = 3, unit = 'months') => {
+  if (pil.status !== 'active') {
+    return pil;
+  }
   pil.reviewDate = pil.reviewDate || moment(pil.updatedAt).add(5, 'years').toISOString();
   return {
     ...pil,

--- a/test/data/default.js
+++ b/test/data/default.js
@@ -89,6 +89,15 @@ module.exports = models => {
         emailConfirmed: true
       },
       {
+        id: ids.profiles.hasRevokedPil,
+        userId: 'hasRevokedPil',
+        title: 'Mr',
+        firstName: 'Has-Revoked',
+        lastName: 'PIL',
+        email: 'hasrevokedpil@example.com',
+        emailConfirmed: true
+      },
+      {
         id: ids.profiles.marvellAdmin,
         userId: 'marvellAdmin',
         title: 'Mr',
@@ -647,6 +656,11 @@ module.exports = models => {
         role: 'basic'
       },
       {
+        profileId: ids.profiles.hasRevokedPil,
+        establishmentId: ids.establishments.croydon,
+        role: 'basic'
+      },
+      {
         profileId: ids.profiles.aaProjectRemoved,
         establishmentId: ids.establishments.croydon,
         role: 'basic'
@@ -749,6 +763,18 @@ module.exports = models => {
         species: ['Mice', 'Rats'],
         updatedAt: '2020-01-01T12:00:00Z',
         reviewDate: '2024-12-01T12:00:00Z'
+      },
+      {
+        id: ids.pils.hasRevokedPil,
+        profileId: ids.profiles.hasRevokedPil,
+        establishmentId: ids.establishments.croydon,
+        status: 'revoked',
+        issueDate: '2015-01-01T12:00:00Z',
+        revocationDate: '2016-12-01T12:00:00Z',
+        procedures: ['C'],
+        species: ['Mice', 'Rats'],
+        updatedAt: '2016-01-01T12:00:00Z',
+        reviewDate: '2021-01-01T12:00:00Z'
       }
     ]))
     .then(() => models.PilTransfer.query().insert([

--- a/test/data/ids.js
+++ b/test/data/ids.js
@@ -17,6 +17,7 @@ module.exports = {
     multipleEstablishments: uuid(),
     vincentMalloy: uuid(),
     hasNoPil: uuid(),
+    hasRevokedPil: uuid(),
     licensing: uuid(),
     marvellAdmin: uuid(),
     unverified: uuid(),
@@ -32,6 +33,7 @@ module.exports = {
     linfordChristie: uuid(),
     noddyHolder: uuid(),
     cliveNacwo: uuid(),
+    hasRevokedPil: uuid(),
     multipleEstablishments: uuid()
   },
   certificates: {

--- a/test/specs/pils.js
+++ b/test/specs/pils.js
@@ -175,6 +175,17 @@ describe('/pils', () => {
         });
     });
 
+    it('does not attach review metadata to revoked pils', () => {
+      return request(this.api)
+        .get(`/establishment/${ids.establishments.croydon}/profile/${ids.profiles.hasRevokedPil}/pil`)
+        .expect(200)
+        .then(response => {
+          const data = response.body.data;
+          assert.equal(data.reviewDue, undefined);
+          assert.equal(data.reviewOverdue, undefined);
+        });
+    });
+
     describe('establishmentName permissions', () => {
       it('includes the establishment if the requesting user has permissions for the holding establishment', () => {
         const can = sinon.stub().resolves(true);

--- a/test/specs/profiles.js
+++ b/test/specs/profiles.js
@@ -27,7 +27,7 @@ describe('/profiles', () => {
       .get(`/establishment/${ids.establishments.croydon}/profiles`)
       .expect(200)
       .expect(response => {
-        assert.equal(response.body.data.length, 9);
+        assert.equal(response.body.data.length, 10);
         response.body.data.forEach(profile => {
           profile.establishments.forEach(establishment => {
             assert.equal(establishment.id, ids.establishments.croydon);

--- a/test/specs/user.js
+++ b/test/specs/user.js
@@ -38,6 +38,18 @@ describe('/me', () => {
         });
     });
 
+    it('does not include PIL review metadata for users with revoked PILs', () => {
+      this.api.setUser({ id: 'hasRevokedPil' });
+      return request(this.api)
+        .get('/me')
+        .expect(200)
+        .expect(response => {
+          assert.equal(response.body.data.pil.reviewDate, '2021-01-01T12:00:00.000Z');
+          assert.equal(response.body.data.pil.reviewDue, undefined);
+          assert.equal(response.body.data.pil.reviewOverdue, undefined);
+        });
+    });
+
     it('includes a list of allowed actions', () => {
       const actions = {
         global: [],


### PR DESCRIPTION
This was causing users with old revoked PILs to see a message on their dashboard prompting them to complete a review for PILs that had been revoked years ago.