### PR TITLE
Add endpoint for fetching user alerts

### DIFF
--- a/lib/routers/profile/alerts.js
+++ b/lib/routers/profile/alerts.js
@@ -80,7 +80,7 @@ const getEstablishmentAlerts = async (profile, models, ropsYears) => {
 
     const pilReviews = await PIL.query()
       .where({ status: 'active' })
-      .where('reviewDate', '<', moment().add(2, 'months'))
+      .where('reviewDate', '<', moment().add(1, 'month'))
       .whereIn('establishmentId', pilReviewEstablishments.map(e => e.id));
 
     pilReviews.forEach(pil => {

--- a/lib/routers/profile/alerts.js
+++ b/lib/routers/profile/alerts.js
@@ -1,0 +1,152 @@
+const { Router } = require('express');
+const moment = require('moment');
+const { permissions } = require('../../middleware');
+
+const raDueQuery = models => {
+  const { Project } = models;
+
+  return Project.query()
+    .whereIn('projects.status', ['expired', 'revoked'])
+    .whereNotNull('projects.raDate')
+    .whereNotExists(
+      Project.relatedQuery('retrospectiveAssessments')
+        .whereIn('retrospectiveAssessments.status', ['submitted', 'granted'])
+    );
+};
+
+const ropsDueQuery = (models, ropsYear) => {
+  const { Project } = models;
+
+  return Project.query()
+    .select('projects.*')
+    .selectRopsDeadline(ropsYear)
+    .whereRopsDue(ropsYear)
+    .whereRopsOutstanding(ropsYear);
+};
+
+const getPersonalAlerts = async (profile, models, ropsYear) => {
+  const alerts = [];
+  const pil = profile.pil;
+
+  if (pil && pil.reviewDue) {
+    alerts.push({
+      type: 'pilReview',
+      model: pil,
+      deadline: pil.reviewDate,
+      overdue: pil.reviewOverdue
+    });
+  }
+
+  const raProjects = await raDueQuery(models).where({ licenceHolderId: profile.id });
+
+  raProjects.forEach(project => {
+    alerts.push({
+      type: 'raDue',
+      model: project,
+      deadline: project.raDate,
+      overdue: moment(project.raDate).isBefore(moment())
+    });
+  });
+
+  const ropsProjects = await ropsDueQuery(models, ropsYear).where({ licenceHolderId: profile.id });
+
+  ropsProjects.forEach(project => {
+    alerts.push({
+      type: 'ropDue',
+      model: project,
+      deadline: project.ropsDeadline,
+      overdue: moment(project.ropsDeadline).isBefore(moment()),
+      ropsYear
+    });
+  });
+
+  return alerts;
+};
+
+function isNtcoAtEstablishment(profile, estId) {
+  return !!(profile.roles || []).find(role => role.establishmentId === estId && role.type === 'ntco');
+}
+
+const getEstablishmentAlerts = async (profile, models, ropsYear) => {
+  const alerts = [];
+  const adminAtEstablishments = (profile.establishments || []).filter(e => e.role === 'admin');
+  const ntcoAtEstablishments = (profile.establishments || []).filter(e => isNtcoAtEstablishment(profile, e.id));
+  const pilReviewEstablishments = adminAtEstablishments.concat(ntcoAtEstablishments);
+
+  if (pilReviewEstablishments.length > 0) {
+    const { PIL } = models;
+
+    const pilReviews = await PIL.query()
+      .where({ status: 'active' })
+      .where('reviewDate', '<', moment().add(2, 'months'))
+      .whereIn('establishmentId', pilReviewEstablishments.map(e => e.id));
+
+    pilReviews.forEach(pil => {
+      alerts.push({
+        type: 'pilReview',
+        model: pil,
+        establishmentId: pil.establishmentId,
+        deadline: pil.reviewDate,
+        overdue: moment(pil.reviewDate).isBefore(moment())
+      });
+    });
+  }
+
+  if (adminAtEstablishments.length > 0) {
+    const raProjects = await raDueQuery(models)
+      .whereIn('projects.establishmentId', adminAtEstablishments.map(e => e.id));
+
+    raProjects.forEach(project => {
+      alerts.push({
+        type: 'raDue',
+        model: project,
+        establishmentId: project.establishmentId,
+        deadline: project.raDate,
+        overdue: moment(project.raDate).isBefore(moment())
+      });
+    });
+
+    const ropsProjects = await ropsDueQuery(models, ropsYear)
+      .whereIn('projects.establishmentId', adminAtEstablishments.map(e => e.id));
+
+    ropsProjects.forEach(project => {
+      alerts.push({
+        type: 'ropDue',
+        model: project,
+        establishmentId: project.establishmentId,
+        deadline: project.ropsDeadline,
+        overdue: moment(project.ropsDeadline).isBefore(moment()),
+        ropsYear
+      });
+    });
+  }
+
+  return alerts;
+};
+
+module.exports = () => {
+  const router = Router({ mergeParams: true });
+
+  router.get('/',
+    permissions('profile.alerts', req => ({ profileId: req.profile.id })),
+    async (req, res, next) => {
+      const personalCutoff = moment().add(3, 'months');
+      const establishmentCutoff = moment().add(1, 'month');
+
+      // TODO: rops alerts for more than a single ROPS year
+      const now = new Date();
+      const ropsYear = now.getMonth() < 6 ? now.getFullYear() - 1 : now.getFullYear();
+
+      const personalAlerts = await getPersonalAlerts(req.profile, req.models, ropsYear);
+      const establishmentAlerts = await getEstablishmentAlerts(req.profile, req.models, ropsYear);
+
+      res.response = {
+        personal: personalAlerts.filter(a => moment(a.deadline).isBefore(personalCutoff)),
+        establishments: establishmentAlerts.filter(a => moment(a.deadline).isBefore(establishmentCutoff))
+      };
+      next();
+    }
+  );
+
+  return router;
+};

--- a/lib/routers/user.js
+++ b/lib/routers/user.js
@@ -6,6 +6,7 @@ const { UnauthorisedError } = require('../errors');
 const personRouter = require('./profile/person');
 const emailPreferencesRouter = require('./profile/email-preferences');
 const notificationsRouter = require('./profile/notifications');
+const alertsRouter = require('./profile/alerts');
 
 module.exports = (settings) => {
   const router = Router();
@@ -96,6 +97,8 @@ module.exports = (settings) => {
   });
 
   router.use(personRouter(settings));
+
+  router.use('/alerts', alertsRouter(settings));
 
   router.get('/', (req, res, next) => {
     const { Invitation } = req.models;


### PR DESCRIPTION
Adds a new endpoint for fetching all the "alerts" the user needs to be aware of.

The alerts are returned for both the user's own licences and for licences at establishments they are admin/NTCO of.

Personal alerts are up to 3 months in advance and establishment alerts are up to 1 month in advance.

In both cases, the alerts include PIL reviews due, RAs due and ROPs due where applicable.
