### PR TITLE
Add refusedAt prop to refused projects

### DIFF
--- a/lib/middleware/index.js
+++ b/lib/middleware/index.js
@@ -6,5 +6,6 @@ module.exports = {
   whitelist: require('./whitelist'),
   validateSchema: require('./validate-schema'),
   updateDataAndStatus: require('./update-data-and-status'),
-  permissionsBypass: require('./permissions-bypass')
+  permissionsBypass: require('./permissions-bypass'),
+  projectWasRefused: require('./project-was-refused')
 };

--- a/lib/middleware/project-was-refused.js
+++ b/lib/middleware/project-was-refused.js
@@ -1,4 +1,4 @@
-const { get } = require('lodash');
+const { get, isArray } = require('lodash');
 
 module.exports = (req, res, next) => {
   let id = get(req, 'project.id');
@@ -13,11 +13,13 @@ module.exports = (req, res, next) => {
     onlyOpen: false,
     establishmentId: req.establishment.id
   }})
-    .then(workflowResponse => {
-      const relatedTasks = workflowResponse.json.data;
-      const refusedTask = relatedTasks.find(task => task.status === 'refused');
-      if (refusedTask) {
-        req.project.refusedAt = refusedTask.updatedAt;
+    .then(workflowResponse => workflowResponse.json.data)
+    .then(relatedTasks => {
+      if (isArray(relatedTasks) && relatedTasks.length > 0) {
+        const refusedTask = relatedTasks.find(task => task.status === 'refused');
+        if (refusedTask) {
+          req.project.refusedAt = refusedTask.updatedAt;
+        }
       }
       next();
     });

--- a/lib/middleware/project-was-refused.js
+++ b/lib/middleware/project-was-refused.js
@@ -1,0 +1,24 @@
+const { get } = require('lodash');
+
+module.exports = (req, res, next) => {
+  let id = get(req, 'project.id');
+
+  if (!id) {
+    return next();
+  }
+
+  return req.workflow.related({ query: {
+    model: 'project',
+    modelId: id,
+    onlyOpen: false,
+    establishmentId: req.establishment.id
+  }})
+    .then(workflowResponse => {
+      const relatedTasks = workflowResponse.json.data;
+      const refusedTask = relatedTasks.find(task => task.status === 'refused');
+      if (refusedTask) {
+        req.project.refusedAt = refusedTask.updatedAt;
+      }
+      next();
+    });
+};

--- a/lib/routers/establishment/project-versions.js
+++ b/lib/routers/establishment/project-versions.js
@@ -2,7 +2,7 @@ const { Router } = require('express');
 const { get, pick } = require('lodash');
 const shasum = require('shasum');
 const isUUID = require('uuid-validate');
-const { permissions, fetchOpenTasks, fetchReminders } = require('../../middleware');
+const { permissions, fetchOpenTasks, fetchReminders, projectWasRefused } = require('../../middleware');
 const { NotFoundError, BadRequestError } = require('../../errors');
 
 const perms = task => permissions(task, req => ({ licenceHolderId: req.project.licenceHolderId }));
@@ -69,6 +69,9 @@ const submit = action => (req, res, next) => {
     .catch(next);
 };
 
+// projectWasRefused modifies req.project with a refusedAt prop, so needs to execute before the `Object.assign(...)` below
+router.use(projectWasRefused);
+
 router.param('versionId', (req, res, next, versionId) => {
   if (!isUUID(versionId)) {
     return next(new NotFoundError());
@@ -100,7 +103,7 @@ router.param('versionId', (req, res, next, versionId) => {
       }
 
       req.version = version;
-      Object.assign(req.version.project, pick(req.project, 'granted', 'draft', 'versions', 'grantedRa', 'draftRa', 'retrospectiveAssessments', 'additionalEstablishments'));
+      Object.assign(req.version.project, pick(req.project, 'granted', 'draft', 'versions', 'grantedRa', 'draftRa', 'retrospectiveAssessments', 'additionalEstablishments', 'refusedAt'));
       next();
     })
     .catch(next);

--- a/lib/routers/establishment/projects.js
+++ b/lib/routers/establishment/projects.js
@@ -3,7 +3,7 @@ const moment = require('moment');
 const { ref } = require('objection');
 const { Router } = require('express');
 const { BadRequestError, NotFoundError } = require('../../errors');
-const { fetchOpenTasks, fetchReminders, permissions, whitelist, updateDataAndStatus } = require('../../middleware');
+const { fetchOpenTasks, fetchReminders, permissions, whitelist, updateDataAndStatus, projectWasRefused } = require('../../middleware');
 
 const router = Router({ mergeParams: true });
 
@@ -351,7 +351,8 @@ router.get('/:projectId',
     next();
   },
   fetchReminders('project'),
-  fetchOpenTasks()
+  fetchOpenTasks(),
+  projectWasRefused
 );
 
 router.post('/',


### PR DESCRIPTION
Once a project application is refused, the task is closed and no-longer gets returned in `project.openTasks`.

If a project was refused then we flag it so various UI elements can be displayed.