### PR TITLE
Optimise performance of establishment loading

### DIFF
--- a/lib/routers/establishment/places.js
+++ b/lib/routers/establishment/places.js
@@ -51,14 +51,22 @@ const validatePlace = (req, res, next) => {
 };
 
 const validateRoles = (req, res, next) => {
+  const { Role } = req.models;
   const roleIds = get(req, 'body.data.roles') || [];
-  const validRoleIds = req.establishment.roles.map(r => r.id);
-
-  if (difference(roleIds, validRoleIds).length !== 0) {
-    throw new BadRequestError('invalid role ids found');
-  }
-
-  return next();
+  Promise.resolve()
+    .then(() => {
+      return Role.query()
+        .select('id')
+        .where('establishmentId', req.establishment.id);
+    })
+    .then(result => {
+      const validRoleIds = result.map(r => r.id);
+      if (difference(roleIds, validRoleIds).length !== 0) {
+        next(new BadRequestError('invalid role ids found'));
+      }
+      next();
+    })
+    .catch(next);
 };
 
 const router = Router({ mergeParams: true });

--- a/test/specs/establishments.js
+++ b/test/specs/establishments.js
@@ -58,18 +58,6 @@ describe('/establishments', () => {
         });
     });
 
-    it('includes the details for the licence holder as `pelh`', () => {
-      return request(this.api)
-        .get(`/establishment/${ids.establishments.croydon}`)
-        .expect(200)
-        .expect(response => {
-          const profile = response.body.data.roles.find(r => r.type === 'pelh').profile;
-
-          assert.equal(profile.firstName, 'Colin');
-          assert.equal(profile.lastName, 'Jackson');
-        });
-    });
-
     it('includes a count of the places at the establishment', () => {
       return request(this.api)
         .get(`/establishment/${ids.establishments.croydon}`)


### PR DESCRIPTION
Every route in this service passes through `app.param('establishment', ...)` since all routes are scoped underneath an establishment, and the loading of the extra establishment metadata is only necessary for calls to the `GET /:establishment` directly.

Loading this metadata (named people, licence counts etc) when passing through to sub-routes adds ~50-100ms to every API call.

The named people route is particularly slow, and is only used in a small number of routes, so extract this out into its own route and call from the UI on the pages where it is strictly necessary.