### PR TITLE
OR needs to be nested to avoid polluting query

### DIFF
--- a/lib/middleware/fetch-reminders.js
+++ b/lib/middleware/fetch-reminders.js
@@ -58,9 +58,11 @@ module.exports = modelType => async (req, res, next) => {
       }
 
       const projectReminders = await remindersQuery({ modelType: 'project', modelId: req.project.id })
-        .where({ status: 'active' })
-        .orWhere(builder => {
-          builder.where({ status: 'pending' }).andWhere('createdAt', '>', req.version.createdAt);
+        .where(qb1 => {
+          qb1.where({ status: 'active' })
+            .orWhere(qb2 => {
+              qb2.where({ status: 'pending' }).andWhere('createdAt', '>', req.version.createdAt);
+            });
         });
 
       if (projectReminders.length > 0) {


### PR DESCRIPTION
Original query:

```
select "reminders".*
from "reminders"
where "reminders"."deleted" is null
and "model_type" = 'project'
and "model_id" = '356835fa-3835-416d-9d11-076e6c85b7f6'
and "status" = 'active'
or ("status" = 'pending' and "created_at" > '2022-10-06T13:39:35.203Z')
order by "reminders"."deadline" asc
```

The `OR` at the top level is bypassing the rest of the where clauses for some records, so soft-deleted records are sometimes returned.