### PR TITLE
Filter non-user-input values from checksum

### DIFF
--- a/lib/routers/establishment/project-versions.js
+++ b/lib/routers/establishment/project-versions.js
@@ -1,5 +1,5 @@
 const { Router } = require('express');
-const { get, pick } = require('lodash');
+const { get, pick, omit } = require('lodash');
 const shasum = require('shasum');
 const isUUID = require('uuid-validate');
 const { permissions, fetchOpenTasks, fetchReminders } = require('../../middleware');
@@ -161,7 +161,8 @@ router.put('/:versionId/:action',
       .findById(req.version.id)
       .then(version => {
         res.response = normalise(version, req.models);
-        res.meta.checksum = shasum(res.response.data);
+        res.meta.checksumOmit = ['id', 'retrospectiveAssessment', 'conditions'];
+        res.meta.checksum = shasum(omit(res.response.data, ...res.meta.checksumOmit));
       })
       .then(() => next())
       .catch(e => next(e));


### PR DESCRIPTION
These values can change in the data as a side-effect of user input but are not directly input values. This means they can trigger discrepancies between the client and server data that are not a result of user changes.

In order to prevent these causing an "edited elsewhere" warning filter them out of the checksum data, and return the list to the client so they can also be filtered there without needing to maintain the list twice.