### PR TITLE
Reject email changes if the new email exists with different casing

### DIFF
--- a/lib/routers/profile/person.js
+++ b/lib/routers/profile/person.js
@@ -49,7 +49,7 @@ const validateEmail = () => {
     }
 
     const { Profile } = req.models;
-    return Profile.query().where({ email })
+    return Profile.query().where('email', 'iLike', email)
       .then(profiles => {
         if (profiles.length > 0) {
           throw new BadRequestError('Email address is already in use');

--- a/test/specs/user.js
+++ b/test/specs/user.js
@@ -137,4 +137,30 @@ describe('/me', () => {
 
   });
 
+  describe('changing email', () => {
+
+    it('rejects if email is in use already', () => {
+      const data = {
+        email: 'test2@example.com'
+      };
+
+      return request(this.api)
+        .put('/me/email')
+        .send({ data })
+        .expect(400);
+    });
+
+    it('rejects if email is in use already with different casing', () => {
+      const data = {
+        email: 'TEST2@example.com'
+      };
+
+      return request(this.api)
+        .put('/me/email')
+        .send({ data })
+        .expect(400);
+    });
+
+  });
+
 });


### PR DESCRIPTION
This is throwing a 500 error to users because the change is eventually rejected by keycloak. Instead update the validation so the API rejects if the email matches with different case.